### PR TITLE
Add a route to monitor the host status

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -44,6 +44,8 @@ class Status:
                 readyToCall += "chrome" not in str(gateway.exec_run("ps -e").output)
 
             except:
+                if i == 0:  # No gateways started yet
+                    callsEnded = False
                 break
 
         return {"readyToCall": readyToCall, "callsEnded": callsEnded}


### PR DESCRIPTION
# Short description

This route checks the number of gateways that are up but not in a call, and if all gateways have ended their calls, meaning the host can be deleted.

Do not forget: since the gateway container takes 5sec to be deleted after the end of a call, the metrics are not accurate during these 5sec.


# Changes

Added a `GET` route in the `web.py` server:
 - `readyToCall` is the number of gateway containers that are up but not in a call
 - `callsEnded` is a boolean telling if all gateways have been used


# Tests

This code was tested on a machine with 3 gateways being used one after the other.