### PR TITLE
Bypass login screen on jitsi web conferences when there is one

### DIFF
--- a/browsing/jitsi.py
+++ b/browsing/jitsi.py
@@ -46,6 +46,7 @@ class Jitsi (Browsing):
         self.url += urlBase
         self.url += '#userInfo.displayName="' + self.name + '"'
         self.url += '&config.enableNoisyMicDetection=false'
+        self.url += '&config.prejoinPageEnabled=false'
 
         print("Web browsing URL: "+self.url, flush=True)
 


### PR DESCRIPTION
Without this, the gateway gets stuck on the Jitsi login screen when there is one