### PR TITLE
Fix sending request retry to transcript and fix temporary file lifecycle

### DIFF
--- a/transcript/transcriptServer.py
+++ b/transcript/transcriptServer.py
@@ -1,8 +1,9 @@
-from fastapi import FastAPI, File, UploadFile, Form
+from fastapi import FastAPI, File, UploadFile, Form, HTTPException
 import os
 import uvicorn
 import logging
 import json
+import time
 from faster_whisper import WhisperModel
 from tempfile import NamedTemporaryFile
 
@@ -34,27 +35,32 @@ async def transcribe(
     """
     try:
         logging.info(f"Received file: {audio.filename}, Model: {model}, Lang: {lang}")
-
+        start_transcribe_time = time.time()
         # Save the uploaded file temporarily
         with NamedTemporaryFile(delete=False, suffix=os.path.splitext(audio.filename)[-1]) as tempFile:
             tempFilePath = tempFile.name
             tempFile.write(await audio.read())
+            tempFile.flush()  # Ensure the file is written to disk
+            tempFile.close()  # Close the file to release the handle
 
-        logging.info(f"File saved at {tempFilePath}")
+        # get file size
+        fileSize = os.path.getsize(tempFilePath)
+        logging.info(f"File saved at {tempFilePath}, Size: {fileSize} bytes")
+
+        if fileSize == 0:
+            logging.error("Uploaded file is empty.")
+            raise HTTPException(status_code=400, detail="Application error: uploaded file is empty.")
 
         # Load the Whisper model
         logging.info(f"Loading model: {model} from {modelPath}")
-        whisperModel = WhisperModel(model, download_root=modelPath)
+        whisperModel = WhisperModel(model, download_root=modelPath,device="cpu", compute_type="int8")
 
         # Transcribe the audio
         transcribeLang = lang if lang else None  # Use provided lang or auto-detect
         logging.info(f"Starting transcription with language: {transcribeLang or 'Auto-Detect'}")
         segments, info = whisperModel.transcribe(tempFilePath, language=transcribeLang)
 
-        # Remove the temporary file
-        os.remove(tempFilePath)
-        logging.info(f"Deleted temp file: {tempFilePath}")
-
+       
         # Get the detected language (if not provided)
         detectedLanguage = None
         if lang:
@@ -73,7 +79,12 @@ async def transcribe(
             })
             #logging.info(f"[{segment.start:.2f}s -> {segment.end:.2f}s] {segment.text}")
 
-        logging.info("Transcription completed successfully")
+        end_transcribe_time = time.time()
+        logging.info("Transcription completed successfully in %.2f seconds", end_transcribe_time - start_transcribe_time)
+
+        # Remove the temporary file
+        os.remove(tempFilePath)
+        logging.info(f"Deleted temp file: {tempFilePath}")
 
         # Return JSON response with timestamps
         return {
@@ -84,7 +95,7 @@ async def transcribe(
 
     except Exception as e:
         logging.exception(f"Error during transcription: {str(e)}")
-        return {"error": str(e)}
+        raise HTTPException(status_code=400, detail="Application error: {}".format(str(e)))
 
 # Run FastAPI server
 if __name__ == "__main__":


### PR DESCRIPTION
Fix 2 bugs in Transcript generation process : 
 - Remove the temporary file after the end of the transcript
 - Reset the file pointer in case of POST request retry from the SipMediaGW container to the transcript container to avoid 0 bytes file in POST.