### PR TITLE
[Changed] centralise Redis mapping field access

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -34,6 +34,18 @@ redis_gw_media_duration_index = 5
 redis_gw_transcript_progress_index = 6
 redis_gw_browsing_index = 7
 
+
+def getPart(parts: list, index: int):
+    """Safely read a mapping field, tolerating entries written before new
+    fields were appended."""
+    return parts[index] if len(parts) > index else None
+
+
+def cleanPart(value):
+    """Normalise a mapping field: empty and 'None' are returned as None."""
+    return value if value and value != "" and value != "None" else None
+
+
 @app.get("/pairing")
 async def pairing_page(request: Request):
     """
@@ -91,7 +103,7 @@ def findAvailableGateway():
         value = redisClient.get(key)
         parts = value.split("|")
         gwIp = parts[redis_gw_ip_index]
-        state = parts[redis_gw_state_index] if len(parts) > redis_gw_state_index else None
+        state = getPart(parts, redis_gw_state_index)
         if state == "started":
             return [key, gwIp]
     return None
@@ -127,18 +139,18 @@ def getGatewayStatusFromRedis(gw_id: str):
         return None
     parts = rawValue.split("|")
     gwIp = parts[redis_gw_ip_index]
-    room = parts[redis_gw_room_index] if len(parts) > redis_gw_room_index else None
-    state = parts[redis_gw_state_index] if len(parts) > redis_gw_state_index else None
-    media_duration = parts[redis_gw_media_duration_index] if len(parts) > redis_gw_media_duration_index else None
-    transcript = parts[redis_gw_transcript_progress_index] if len(parts) > redis_gw_transcript_progress_index else None
-    browsing = parts[redis_gw_browsing_index] if len(parts) > redis_gw_transcript_progress_index else None
+    room = getPart(parts, redis_gw_room_index)
+    state = getPart(parts, redis_gw_state_index)
+    media_duration = getPart(parts, redis_gw_media_duration_index)
+    transcript = getPart(parts, redis_gw_transcript_progress_index)
+    browsing = getPart(parts, redis_gw_browsing_index)
     return {
         "status": "success",
         "data": {
             "gw_id": gw_id,
             "gw_state": state,
-            "room": room if room and room != "" and room != "None" else None,
-            "browsing": browsing if browsing and browsing != "" and browsing != "None" else None,
+            "room": cleanPart(room),
+            "browsing": cleanPart(browsing),
             "media_duration": media_duration,
             "transcript_progress": transcript
         }
@@ -163,11 +175,11 @@ async def adminStatus(request: Request):
             continue
         parts = raw.split("|")
         gwIp = parts[redis_gw_ip_index]
-        room = parts[redis_gw_room_index] if len(parts) > redis_gw_room_index else None
-        state = parts[redis_gw_state_index] if len(parts) > redis_gw_state_index else None
-        media_duration = parts[redis_gw_media_duration_index] if len(parts) > redis_gw_media_duration_index else None
-        transcript = parts[redis_gw_transcript_progress_index] if len(parts) > redis_gw_transcript_progress_index else None
-        browsing = parts[redis_gw_browsing_index] if len(parts) > redis_gw_browsing_index else None
+        room = getPart(parts, redis_gw_room_index)
+        state = getPart(parts, redis_gw_state_index)
+        media_duration = getPart(parts, redis_gw_media_duration_index)
+        transcript = getPart(parts, redis_gw_transcript_progress_index)
+        browsing = getPart(parts, redis_gw_browsing_index)
 
         result[gw_id] = {
             "gateway": gwIp,
@@ -414,6 +426,7 @@ async def stopGateway(request: Request):
         detailsRes = responseJson.get("data", {}).get("processing_state", "")
         if "stopping" in detailsRes or "stopped" in detailsRes:
             # Mark as stopped
+            parts += [""] * (redis_gw_field_count - len(parts))
             parts[redis_gw_room_index] = ''
             parts[redis_gw_browsing_index] = ''
             parts[redis_gw_state_index] = "stopped"
@@ -459,7 +472,7 @@ async def statusGateway(request: Request, gw_id: str = None, room: str = None):
             if not rawValue:
                 continue
             parts = rawValue.split("|")
-            gwRoom = parts[redis_gw_room_index] if len(parts) > redis_gw_room_index else None
+            gwRoom = getPart(parts, redis_gw_room_index)
             if gwRoom == room:
                 gw_id = key.split(":")[-1]
                 break
@@ -474,7 +487,7 @@ async def statusGateway(request: Request, gw_id: str = None, room: str = None):
     gwIp = parts[redis_gw_ip_index]
 
     # ----- Refresh baresip gateways on demand --------------------
-    gw_type = parts[redis_gw_type_index] if len(parts) > redis_gw_type_index else None
+    gw_type = getPart(parts, redis_gw_type_index)
     if gw_type == "baresip":
         # call the on‑demand monitor to get a fresh status
         await monitorOneGateway(gw_id, gwIp)


### PR DESCRIPTION
Replace the repeated 'parts[i] if len(parts) > i else None' guards with a getPart() helper, and factor out the empty/'None' normalisation into cleanPart(). Two latent defects are removed along the way:

- getGatewayStatusFromRedis() guarded 'browsing' with the transcript index instead of its own;
- stopGateway() wrote to parts[...] without padding the list first, unlike every other writer.

Neither is reachable today, mappings always being written full-length.