### PR TITLE
[Fixed] read Redis host and port from the environment

### DIFF
--- a/deploy/proxyAPI/docker-compose.yml
+++ b/deploy/proxyAPI/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     image: python:3.12-slim
     container_name: proxy
     working_dir: /app
+    environment:
+      - REDIS_HOST=redis
     volumes:
       - .:/app
     command: >

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -15,7 +15,9 @@ from urllib.parse import quote_plus
 
 app = FastAPI()
 
-redisClient = redis.Redis(host='127.0.0.1', port=6379, decode_responses=True)
+redisClient = redis.Redis(host=os.getenv('REDIS_HOST', '127.0.0.1'),
+                          port=int(os.getenv('REDIS_PORT', '6379')),
+                          decode_responses=True)
 allowedToken = "1234"
 adminToken = "admin-secret-key"  # Change this to a secure admin key
 


### PR DESCRIPTION
The Redis connection was hardcoded to 127.0.0.1, which inside a container refers to the proxy container itself rather than the redis service declared next to it in the same compose file. Every route touching Redis therefore returned 500 on a plain 'docker compose up'.

Host and port are now read from REDIS_HOST and REDIS_PORT, with the current values kept as defaults so that running the proxy outside of a container is unaffected. The compose file passes the service name.