### PR TITLE
[Added] record CALL_ESTABLISHED in the gateway history

### DIFF
--- a/src/logParse.py
+++ b/src/logParse.py
@@ -479,7 +479,7 @@ def main() -> None:
     videoAutoIndex = -1
     lastFinalCallId: Optional[str] = None
 
-    callStartLogged = False
+    gwStartLogged = False
 
     for raw in sys.stdin:
         cleaned = ansiEscapeRegex.sub("", raw)
@@ -496,8 +496,8 @@ def main() -> None:
                 continue
 
             try:
-                ### Call start ###
-                if (not callStartLogged) and ("Web browsing URL:" in line):
+                ### Gateway start ###
+                if (not gwStartLogged) and ("Web browsing URL:" in line):
                     dt = utcNow()
                     url = ""
                     if "URL:" in line:
@@ -505,10 +505,10 @@ def main() -> None:
 
                     appendHistory(
                         historyFile,
-                        "call_start",
+                        "gw_start",
                         {"raw": rawTimestamp(dt), "timestamp": isoZ(dt), "url": url},
                     )
-                    callStartLogged = True
+                    gwStartLogged = True
                     continue
 
                 ### Room ###
@@ -538,15 +538,10 @@ def main() -> None:
                         lastType = str(eventDict.get("type") or "").strip()
 
                         ### Call established: trace the connected endpoint ###
-                        # CALL_ESTABLISHED is the only event signalling that a
-                        # SIP endpoint is actually connected. Without it, an idle
-                        # gateway and a gateway sitting in the IVR are
-                        # indistinguishable (room/browsing are set later, only
-                        # once a conference is joined).
                         if lastType == "CALL_ESTABLISHED":
                             appendHistory(
                                 historyFile,
-                                "call_established",
+                                "call_start",
                                 {
                                     "timestamp": isoZ(utcNow()),
                                     "callId": str(eventDict.get("id") or "").strip(),

--- a/src/logParse.py
+++ b/src/logParse.py
@@ -536,6 +536,30 @@ def main() -> None:
                     eventDict = parseEventDict(line)
                     if eventDict and eventDict.get("class") == "call":
                         lastType = str(eventDict.get("type") or "").strip()
+
+                        ### Call established: trace the connected endpoint ###
+                        # CALL_ESTABLISHED is the only event signalling that a
+                        # SIP endpoint is actually connected. Without it, an idle
+                        # gateway and a gateway sitting in the IVR are
+                        # indistinguishable (room/browsing are set later, only
+                        # once a conference is joined).
+                        if lastType == "CALL_ESTABLISHED":
+                            appendHistory(
+                                historyFile,
+                                "call_established",
+                                {
+                                    "timestamp": isoZ(utcNow()),
+                                    "callId": str(eventDict.get("id") or "").strip(),
+                                    "sourceURI": normalizeSipUri(
+                                        str(eventDict.get("peeruri") or "").strip()
+                                    ),
+                                    "peerDisplayName": str(
+                                        eventDict.get("peerdisplayname") or ""
+                                    ).strip(),
+                                },
+                            )
+                            continue
+
                         if lastType != "CALL_CLOSED":
                             continue
 


### PR DESCRIPTION
CALL_ESTABLISHED is the only event signalling that a SIP endpoint is actually connected to a gateway, but logParse discards every call event except CALL_CLOSED. As a result an idle gateway and a gateway carrying a live call in the IVR are indistinguishable: call_start is written when the IVR page loads at container startup, and room/browsing only appear once the IVR selection completes.

The event is now recorded in the history file, following the same pattern as the existing call_closed handling, with the call id, the normalised peer URI and the peer display name.

Nothing reads the new entry yet; it is added on its own so that follow-up changes surfacing it through the API can be reviewed separately.