### PR TITLE
[Added] connected endpoint identity in gateway status

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -317,17 +317,17 @@ class DockerGateway:
         resp["room"] = ""
         resp["peer_uri"] = ""
         resp["peer_name"] = ""
-        # A call_established entry means a SIP endpoint is connected, even when
+        # A call_start entry means a SIP endpoint is connected, even when
         # no conference has been joined yet (room/browsing are set later, once
         # the IVR selection completes).
-        if 'call_established' in history:
-            established = history['call_established'][-1]
-            if isinstance(established, dict):
-                resp["peer_uri"] = established.get("sourceURI", "") or ""
-                resp["peer_name"] = self.parseDisplayName(
-                    established.get("peerDisplayName", "")
-                )
         if 'call_start' in history:
+            call = history['call_start'][-1]
+            if isinstance(call, dict):
+                resp["peer_uri"] = call.get("sourceURI", "") or ""
+                resp["peer_name"] = self.parseDisplayName(
+                    call.get("peerDisplayName", "")
+                )
+        if 'gw_start' in history:
             if 'room' in history:
                 resp["room"] = history['room'][-1]['value']
             if 'browsing' in history:

--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -153,6 +153,31 @@ class DockerGateway:
                 result.setdefault(key, []).append(parsed)
         return result
 
+    @staticmethod
+    def parseDisplayName(raw: str) -> str:
+        """
+        Strip the routing prefix from the peer display name.
+
+        Endpoints encode the dialled service in the display name as
+        "<targetLen>-<target><name>", where <target> is the service prefix
+        ("0" for the IVR, "3.<room>" for the Visio service):
+
+            "1-0TOTO"                -> "TOTO"
+            "12-3.azertyuiopTOTO"    -> "TOTO"
+
+        Mirrors the decoding performed in src/event_handler.py on
+        CALL_ESTABLISHED. Returns the input unchanged when it carries no
+        routing prefix.
+        """
+        value = (raw or "").strip()
+        if not value:
+            return ""
+        try:
+            prefix, remainder = value.split("-", 1)
+            return remainder[int(prefix):].strip()
+        except (ValueError, IndexError):
+            return value
+
     def start_gateway(self, req: StartRequest) -> Dict[str, Any]:
         print(f"[START CONTAINER] for gateway room={req.room} main_app={req.main_app}")
         gwSubProc = ['./SIPMediaGW.sh']
@@ -290,6 +315,18 @@ class DockerGateway:
         history = self.parseHistoryFile(historyFile)
         resp["browsing"] = ""
         resp["room"] = ""
+        resp["peer_uri"] = ""
+        resp["peer_name"] = ""
+        # A call_established entry means a SIP endpoint is connected, even when
+        # no conference has been joined yet (room/browsing are set later, once
+        # the IVR selection completes).
+        if 'call_established' in history:
+            established = history['call_established'][-1]
+            if isinstance(established, dict):
+                resp["peer_uri"] = established.get("sourceURI", "") or ""
+                resp["peer_name"] = self.parseDisplayName(
+                    established.get("peerDisplayName", "")
+                )
         if 'call_start' in history:
             if 'room' in history:
                 resp["room"] = history['room'][-1]['value']

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -20,10 +20,10 @@ allowedToken = "1234"
 adminToken = "admin-secret-key"  # Change this to a secure admin key
 
 # Redis Mapping:
-# gateway:<gw_id> => "<gw_ip>|<state>|type|room_name|start_time|<media_duration>|<transcript_progress>|<browsing>"
+# gateway:<gw_id> => "<gw_ip>|<state>|type|room_name|start_time|<media_duration>|<transcript_progress>|<browsing>|<peer_uri>|<peer_name>"
 # state: started | working | stopped
 
-redis_gw_field_count = 8
+redis_gw_field_count = 10
 
 redis_gw_ip_index = 0
 redis_gw_state_index = 1
@@ -33,6 +33,8 @@ redis_gw_start_time_index = 4
 redis_gw_media_duration_index = 5
 redis_gw_transcript_progress_index = 6
 redis_gw_browsing_index = 7
+redis_gw_peer_uri_index = 8
+redis_gw_peer_name_index = 9
 
 @app.get("/pairing")
 async def pairing_page(request: Request):
@@ -103,6 +105,8 @@ def updateProgressInfo(gw_id: str, parts: list, data: dict):
     state  = data.get("gw_state")
     room = data.get("room")
     browsing = data.get("browsing")
+    peerUri = data.get("peer_uri")
+    peerName = data.get("peer_name")
     parts += [""] * (redis_gw_field_count - len(parts) )
     if recording:
         parts[redis_gw_media_duration_index] = f"{recording}"
@@ -117,6 +121,8 @@ def updateProgressInfo(gw_id: str, parts: list, data: dict):
         parts[redis_gw_state_index] = "started"
     parts[redis_gw_room_index] = f"{room}" if room else "None"
     parts[redis_gw_browsing_index] = f"{browsing}" if browsing else "None"
+    parts[redis_gw_peer_uri_index] = f"{peerUri}" if peerUri else "None"
+    parts[redis_gw_peer_name_index] = f"{peerName}" if peerName else "None"
 
     mapping = "|".join(parts)
     redisClient.set(f"gateway:{gw_id}", mapping)
@@ -132,6 +138,8 @@ def getGatewayStatusFromRedis(gw_id: str):
     media_duration = parts[redis_gw_media_duration_index] if len(parts) > redis_gw_media_duration_index else None
     transcript = parts[redis_gw_transcript_progress_index] if len(parts) > redis_gw_transcript_progress_index else None
     browsing = parts[redis_gw_browsing_index] if len(parts) > redis_gw_transcript_progress_index else None
+    peerUri = parts[redis_gw_peer_uri_index] if len(parts) > redis_gw_peer_uri_index else None
+    peerName = parts[redis_gw_peer_name_index] if len(parts) > redis_gw_peer_name_index else None
     return {
         "status": "success",
         "data": {
@@ -139,6 +147,8 @@ def getGatewayStatusFromRedis(gw_id: str):
             "gw_state": state,
             "room": room if room and room != "" and room != "None" else None,
             "browsing": browsing if browsing and browsing != "" and browsing != "None" else None,
+            "peer_uri": peerUri if peerUri and peerUri != "" and peerUri != "None" else None,
+            "peer_name": peerName if peerName and peerName != "" and peerName != "None" else None,
             "media_duration": media_duration,
             "transcript_progress": transcript
         }
@@ -168,6 +178,8 @@ async def adminStatus(request: Request):
         media_duration = parts[redis_gw_media_duration_index] if len(parts) > redis_gw_media_duration_index else None
         transcript = parts[redis_gw_transcript_progress_index] if len(parts) > redis_gw_transcript_progress_index else None
         browsing = parts[redis_gw_browsing_index] if len(parts) > redis_gw_browsing_index else None
+        peerUri = parts[redis_gw_peer_uri_index] if len(parts) > redis_gw_peer_uri_index else None
+        peerName = parts[redis_gw_peer_name_index] if len(parts) > redis_gw_peer_name_index else None
 
         result[gw_id] = {
             "gateway": gwIp,
@@ -175,7 +187,9 @@ async def adminStatus(request: Request):
             "room": room if room else None,
             "media_duration": media_duration,
             "transcript_progress": transcript,
-            "browsing": browsing if browsing else None
+            "browsing": browsing if browsing else None,
+            "peer_uri": peerUri if peerUri else None,
+            "peer_name": peerName if peerName else None
         }
     return result
 
@@ -416,6 +430,8 @@ async def stopGateway(request: Request):
             # Mark as stopped
             parts[redis_gw_room_index] = ''
             parts[redis_gw_browsing_index] = ''
+            parts[redis_gw_peer_uri_index] = ''
+            parts[redis_gw_peer_name_index] = ''
             parts[redis_gw_state_index] = "stopped"
             mapping = "|".join(parts)
             redisClient.set(f"gateway:{gw_id}", mapping)
@@ -624,6 +640,8 @@ async def registerGateway(request: Request):
             mediaduration   = parts[redis_gw_media_duration_index]
             transcriptprog  = parts[redis_gw_transcript_progress_index]
             browsing      = parts[redis_gw_browsing_index]
+            peerUri       = parts[redis_gw_peer_uri_index]
+            peerName      = parts[redis_gw_peer_name_index]
         else:
             # No mapping found => reset
             gwState = "started"
@@ -632,12 +650,14 @@ async def registerGateway(request: Request):
             mediaduration   = "0"
             transcriptprog  = "0"
             browsing      = None
+            peerUri       = None
+            peerName      = None
 
         # Build new mapping
         # format : gwIp|state|type|room|startTime|media|transcript|browsing
         gwValue = (
             f"{gwIp}|{gwState}|{gwType}|{roomName}|{startTime}|"
-            f"{mediaduration}|{transcriptprog}|{browsing}"
+            f"{mediaduration}|{transcriptprog}|{browsing}|{peerUri}|{peerName}"
         )
         redisClient.set(f"gateway:{gwId}", gwValue)
         print(f"Gateway registered / updated: {gwId} ({gwIp})")

--- a/src/logParse.py
+++ b/src/logParse.py
@@ -536,6 +536,30 @@ def main() -> None:
                     eventDict = parseEventDict(line)
                     if eventDict and eventDict.get("class") == "call":
                         lastType = str(eventDict.get("type") or "").strip()
+
+                        ### Call established: trace the connected endpoint ###
+                        # CALL_ESTABLISHED is the only event signalling that a
+                        # SIP endpoint is actually connected. Without it, an idle
+                        # gateway and a gateway sitting in the IVR are
+                        # indistinguishable (room/browsing are set later, only
+                        # once a conference is joined).
+                        if lastType == "CALL_ESTABLISHED":
+                            appendHistory(
+                                historyFile,
+                                "call_established",
+                                {
+                                    "timestamp": isoZ(utcNow()),
+                                    "callId": str(eventDict.get("id") or "").strip(),
+                                    "sourceURI": normalizeSipUri(
+                                        str(eventDict.get("peeruri") or "").strip()
+                                    ),
+                                    "peerDisplayName": str(
+                                        eventDict.get("peerdisplayname") or ""
+                                    ).strip(),
+                                },
+                            )
+                            continue
+
                         if lastType != "CALL_CLOSED":
                             continue
 


### PR DESCRIPTION
Depends on #<[numéro de la PR 03](https://github.com/Renater/SIPMediaGW/pull/48))>. 
Once that one is merged, this branch will be rebased on main so that only the second commit remains.

Nothing in the API told which endpoint was connected to a gateway, which
made troubleshooting a user report require correlating logs by hand: the
gateway id is regenerated on every container recreation and is not a usable
reference for first-line support.

get_status now surfaces the call_established history entry as peer_uri and
peer_name, and the proxy propagates both through the Redis mapping. They are
appended at the end of the mapping, leaving existing indexes untouched.

Both forms are exposed on purpose: depending on the deployment, endpoints are
identified by their number (URI) or by their room label (display name), and
support staff may have either one at hand. A helper strips the routing prefix
endpoints embed in the display name, mirroring the decoding already performed
in src/event_handler.py.

[PR-04_expose-peer-identity.md](https://github.com/user-attachments/files/31378639/PR-04_expose-peer-identity.md)

