### PR TITLE
[Added] gateway type in status responses

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -146,10 +146,12 @@ def getGatewayStatusFromRedis(gw_id: str):
     media_duration = getPart(parts, redis_gw_media_duration_index)
     transcript = getPart(parts, redis_gw_transcript_progress_index)
     browsing = getPart(parts, redis_gw_browsing_index)
+    gwType = getPart(parts, redis_gw_type_index)
     return {
         "status": "success",
         "data": {
             "gw_id": gw_id,
+            "gw_type": cleanPart(gwType),
             "gw_state": state,
             "room": cleanPart(room),
             "browsing": cleanPart(browsing),
@@ -182,9 +184,11 @@ async def adminStatus(request: Request):
         media_duration = getPart(parts, redis_gw_media_duration_index)
         transcript = getPart(parts, redis_gw_transcript_progress_index)
         browsing = getPart(parts, redis_gw_browsing_index)
+        gwType = getPart(parts, redis_gw_type_index)
 
         result[gw_id] = {
             "gateway": gwIp,
+            "type": cleanPart(gwType),
             "status": state,
             "room": room if room else None,
             "media_duration": media_duration,


### PR DESCRIPTION
gw_type (baresip, recording, streaming) is sent by gateways on registration and stored in the mapping, but never returned. Consumers therefore cannot tell the three kinds apart, although they behave differently: media_duration and transcript_progress are only meaningful for recording gateways, and a stopped container is an expected state for a pre-provisioned recording gateway while it usually is not for baresip.

The proxy already discriminates on that field internally, statusGateway only triggering the on-demand monitor for baresip gateways, so the distinction is established; it was simply not exposed.

No mapping change: the value is already written by registerGateway.

[PR-06_expose-gw-type.md](https://github.com/user-attachments/files/31379119/PR-06_expose-gw-type.md)