### PR TITLE
[Fixed] NameError in /admin/statuses

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -192,6 +192,8 @@ async def adminStatus(request: Request):
         transcript = getPart(parts, redis_gw_transcript_progress_index)
         browsing = getPart(parts, redis_gw_browsing_index)
         gwType = getPart(parts, redis_gw_type_index)
+        peerUri = getPart(parts, redis_gw_peer_uri_index)
+        peerName = getPart(parts, redis_gw_peer_name_index)
 
         result[gw_id] = {
             "gateway": gwIp,


### PR DESCRIPTION
adminStatus() uses peerUri and peerName in the response dict but never assigns them from the mapping, so every request to /admin/statuses fails with:

    NameError: name 'peerUri' is not defined

The two getPart() calls were lost when #49 and #50 were merged: both touched the same block, and the equivalent lines for browsing and gwType are present.

The route is not covered by the test suite, which is why CI did not catch this.