### PR TITLE
[Fixed] expose peer identity on /status as well

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -154,6 +154,8 @@ def getGatewayStatusFromRedis(gw_id: str):
     transcript = getPart(parts, redis_gw_transcript_progress_index)
     browsing = getPart(parts, redis_gw_browsing_index)
     gwType = getPart(parts, redis_gw_type_index)
+    peerUri = getPart(parts, redis_gw_peer_uri_index)
+    peerName = getPart(parts, redis_gw_peer_name_index)
     return {
         "status": "success",
         "data": {
@@ -162,6 +164,8 @@ def getGatewayStatusFromRedis(gw_id: str):
             "gw_state": state,
             "room": cleanPart(room),
             "browsing": cleanPart(browsing),
+            "peer_uri": cleanPart(peerUri),
+            "peer_name": cleanPart(peerName),
             "media_duration": media_duration,
             "transcript_progress": transcript
         }
@@ -668,7 +672,7 @@ async def registerGateway(request: Request):
             peerName      = None
 
         # Build new mapping
-        # format : gwIp|state|type|room|startTime|media|transcript|browsing
+        # format : gwIp|state|type|room|startTime|media|transcript|browsing|peerUri|peerName
         gwValue = (
             f"{gwIp}|{gwState}|{gwType}|{roomName}|{startTime}|"
             f"{mediaduration}|{transcriptprog}|{browsing}|{peerUri}|{peerName}"


### PR DESCRIPTION
getGatewayStatusFromRedis() did not surface peer_uri and peer_name, so /status returned less than /admin/statuses for the same gateway. The gw_type field added at the same time is present in both, so this looks like a merge oversight between #49 and #50 rather than a deliberate difference.

Also updates the mapping format comment in registerGateway(), which still listed eight fields while ten are written.


/status and /admin/statuses returned different field sets for the same gateway: peer_uri and peer_name were missing from the former. gw_type, added at the same time, is present in both — hence the assumption of a merge oversight rather than an intentional difference.

Also fixes the mapping format comment in registerGateway(), which still listed eight fields.

Verified on a running deployment: /status?gw_id=… now returns both fields, null when the gateway is idle and set once a call is established.