### PR TITLE
[Added] pairing code in /admin/statuses

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -187,6 +187,15 @@ async def adminStatus(request: Request):
             media_type="application/json"
         )
 
+    # Redis stores pairing:<code> -> gw_id, while the console needs the
+    # reverse. Codes have a short TTL, so the value only holds at the
+    # time of the request.
+    pairingByGateway = {}
+    for pairingKey in redisClient.scan_iter(match="pairing:*"):
+        pairedGwId = redisClient.get(pairingKey)
+        if pairedGwId:
+            pairingByGateway[pairedGwId] = pairingKey.split(":", 1)[1]
+
     result = {}
     for key in redisClient.scan_iter(match="gateway:*"):
         gw_id = key.split(":")[-1]
@@ -215,7 +224,8 @@ async def adminStatus(request: Request):
             "browsing": browsing if browsing else None,
             "peer_uri": peerUri if peerUri else None,
             "peer_name": peerName if peerName else None,
-            "call_started": callStarted if callStarted else None
+            "call_started": callStarted if callStarted else None,
+            "pairing_code": pairingByGateway.get(gw_id)
         }
     return result
 


### PR DESCRIPTION
The pairing code displayed on screen during a call is stored in Redis as pairing:<code> -> gw_id, which is the opposite of what a console needs. adminStatus now builds the reverse index and returns the code alongside each gateway.

This is useful for first-line support: reading the code out to a user lets them reach the control page from their phone without having to scan the QR overlay, which is not always legible from the room.

Codes have a short TTL and rotate, so the value only holds at the time of the request. It is returned by /admin/statuses only, not by /status.