### PR TITLE
[Fixed] route requests when SIP_DOMAIN holds several domains

### DIFF
--- a/deploy/kamailio/config/request_gw.py
+++ b/deploy/kamailio/config/request_gw.py
@@ -23,7 +23,8 @@ class RequestGw:
     def __init__(self):
         Logger.LM_ERR('RequestGw.__init__\n')
         sipSecret=os.environ.get('SIP_SECRET').replace('"',"").replace("'", "")
-        self.sipDomain=os.environ.get('SIP_DOMAIN').replace('"',"").replace("'", "")
+        self.sipDomains=[d.strip() for d in os.environ.get('SIP_DOMAIN', '')
+                         .replace('"',"").replace("'", "").split(',') if d.strip()]
         self.publicIP=os.environ.get('PUBLIC_IP').replace('"',"").replace("'", "")
         self.gwNamePart = os.environ.get('GW_NAME_PREFIX').replace('"',"").replace("'", "")
         KSR.pv.sets("$var(secret)", sipSecret)
@@ -101,7 +102,7 @@ class RequestGw:
         Logger.LM_ERR("Loggers.py:      LM_ERR: msg: %s" % str(args))
         Logger.LM_ERR('RequestGw.handler(%s, %s)\n' % (msg.Type, str(args)))
         if (msg.Type == 'SIP_REQUEST' and
-            ((msg.RURI).find(self.sipDomain) != -1 or
+            (any((msg.RURI).find(d) != -1 for d in self.sipDomains) or
              (msg.RURI).find(self.publicIP) != -1)):
             if msg.Method == 'INVITE' and (msg.RURI).find(self.gwNamePart) == -1:
                 Logger.LM_ERR('SIP request, method = %s, RURI = %s, From = %s\n' % (msg.Method, msg.RURI, msg.getHeader('from')))


### PR DESCRIPTION
SIP_DOMAIN accepts a comma separated list since the aliases are split one by one at startup, but request_gw still compared the whole string against the Request-URI. With more than one domain the substring search can never match, so no gateway is allocated and no request is routed — including for the first domain of the list.

The variable is now split the same way kamailioRun does, and each domain is tested in turn.

Verified on a lab with a registered Cisco endpoint calling through a SIP trunk

SIP_DOMAIN | Result
-- | --
visio.numerique.gouv.fr | routed
visio…,webconf… before the fix | RequestGw.handler logged, then nothing — no gateway allocated, for either domain
visio…,webconf… after the fix | both domains routed, 0@, and 3.<room>@

Worth noting the failure is not limited to the extra domains: adding a second one breaks the first as well, which is not obvious from reading the change that introduced the list.