### PR TITLE
[Added] Visio media state exposure and mediaState command

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -477,6 +477,13 @@ class DockerGateway:
                 "return window.meeting.slideShot();"
             )
             return {"ack": True, "slideImg": slideImgB64}
+        elif payload['command'] == 'mediaState':
+            mediaState = self.executeInExistingChromeSession(
+                gwId,
+                "return (window.meeting && window.meeting.mediaState) ? "
+                "window.meeting.mediaState() : null;"
+            )
+            return {"ack": True, "mediaState": mediaState}
         elif payload['command'] == 'microphone':
             microphoneState = payload.get('param1')
             if microphoneState not in ('on', 'off'):

--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -93,17 +93,32 @@ class Visio extends UIHelper{
             return null;
         }
     }
+    mediaState() {
+        const el = document.getElementById('media-state');
+        if (!el) {
+            console.error('[✗] media-state element not found');
+            return null;
+        }
+        return {
+            microphone: el.dataset.microphoneEnabled === 'true',
+            camera: el.dataset.cameraEnabled === 'true'
+        };
+    }
     microphone(param) {
-        const microphoneButton = document.querySelector('[aria-label*="Ctrl+d"]');
-        if (!microphoneButton) {
-            console.error('[✗] Microphone button not found');
+        const state = this.mediaState();
+        if (!state) {
             return;
         }
 
-        const muted = microphoneButton.getAttribute('aria-pressed') === 'true';
-        const shouldToggle = (param === 'on' && muted) || (param === 'off' && !muted);
+        const shouldToggle = (param === 'on' && !state.microphone) ||
+                             (param === 'off' && state.microphone);
 
         if (shouldToggle) {
+            const microphoneButton = document.querySelector('[aria-label*="Ctrl+d"]');
+            if (!microphoneButton) {
+                console.error('[✗] Microphone button not found');
+                return;
+            }
             microphoneButton.click();
         }
     }


### PR DESCRIPTION
visio.js: read microphone/camera state from the #media-state element exposed by Visio for external gateways (meet >= 1.25.0), instead of the aria-pressed attribute of a button matched on its tooltip label. microphone(on|off) now relies on it, keeping the command idempotent.

HTTPLauncher.py: new 'mediaState' command returning the connector media state, or null when the connector does not implement the method, so a client can query any gateway without knowing the platform.

Note: on Visio this requires meet >= 1.25.0. No fallback is kept.