### PR TITLE
[Added] Visio reactions support

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -477,6 +477,20 @@ class DockerGateway:
                 "return window.meeting.slideShot();"
             )
             return {"ack": True, "slideImg": slideImgB64}
+        elif payload['command'] == 'reaction':
+            reactionName = payload.get('param1')
+            if not reactionName:
+                raise ValueError("reaction requires param1")
+            ok = self.executeInExistingChromeSession(
+                gwId,
+                "return (window.meeting && window.meeting.reaction) ? "
+                "window.meeting.reaction(arguments[0]) : false;",
+                reactionName
+            )
+            if not ok:
+                raise ValueError(
+                    "reaction '{}' not supported by this connector".format(reactionName))
+            return {"ack": True, "reaction": reactionName}
         elif payload['command'] == 'microphone':
             microphoneState = payload.get('param1')
             if microphoneState not in ('on', 'off'):

--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -107,7 +107,45 @@ class Visio extends UIHelper{
             microphoneButton.click();
         }
     }
+    async reaction(name) {
+        const known = ['thumbs-up', 'thumbs-down', 'clapping-hands', 'red-heart',
+                       'face-with-tears-of-joy', 'face-with-open-mouth',
+                       'party-popper', 'folded-hands'];
+        if (!known.includes(name)) {
+            console.error('[✗] Unknown reaction: ' + name);
+            return false;
+        }
+        const toggle = document.querySelector('[data-attr="reactions-toggle"]');
+        if (!toggle) {
+            console.error('[✗] Reactions toggle not found');
+            return false;
+        }
+        if (toggle.getAttribute('aria-expanded') !== 'true') {
+            toggle.click();
+        }
+        try {
+            const button = await this.waitForElement(
+                '[data-attr="send-reaction-' + name + '"]', { clickable: true }, 2000);
+            button.click();
+        } catch (e) {
+            console.error('[✗] Reaction button not reachable: ' + name);
+            return false;
+        } finally {
+            if (toggle.getAttribute('aria-expanded') === 'true') {
+                toggle.click();
+            }
+        }
+        return true;
+    }
     interact(key) {
+        const reactionKeys = {
+            "6": "thumbs-up",
+            "7": "red-heart",
+            "8": "clapping-hands",
+            "9": "face-with-tears-of-joy"
+        };
+        if (key in reactionKeys)
+            this.reaction(reactionKeys[key]);
         if (key == "1")
             document.querySelector('[aria-label*="Ctrl+d"]').click();
         if (key == "2")


### PR DESCRIPTION
visio.js: new reaction(name) method sending one of the eight Visio reactions through the [data-attr=send-reaction-*] buttons, opening and closing the reactions toolbar around the click. interact() maps keys 6-9 to thumbs-up, red-heart, clapping-hands and face-with-tears-of-joy, so DTMF-only endpoints (Poly, Yealink, Huawei) can send reactions too.

HTTPLauncher.py: new 'reaction' command taking the reaction name in param1, raising an error when the connector does not support it instead of silently returning 200 OK.