### PR TITLE
[Fixed] sendChat now reaches the connector directly

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -459,12 +459,15 @@ class DockerGateway:
                 out, err = res.communicate()
         elif payload['command'] == 'sendChat':
             msg = payload['param1']
-            gwSubProc = ['docker', 'exec', gwName,
-                            'sh', '-c',
-                            ('if [ -p ./chatFifo ]; then '
-                             'printf "%s\n" "{}" > ./chatFifo; fi'.format(msg))]
-            res = subprocess.Popen(gwSubProc, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out, err = res.communicate()
+            ok = self.executeInExistingChromeSession(
+                gwId,
+                "return (window.meeting && window.meeting.sendChat) ? "
+                "window.meeting.sendChat(arguments[0]) : false;",
+                msg
+            )
+            if not ok:
+                raise ValueError("sendChat failed or not supported by this connector")
+            return {"ack": True, "sendChat": True}
         elif payload['command'] == 'endCall':
             gwSubProc = ['docker', 'exec', gwName,
                             'sh', '-c',

--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -190,27 +190,46 @@ class Visio extends UIHelper{
             setTimeout(() => clearInterval(interval), 5000);
         }
     }
-    sendChat(message) {
-        const textarea = document.querySelector('textarea');
-        if (!textarea) {
-            return;
+    async sendChat(message) {
+        if (!message || !String(message).trim()) {
+            console.error('[\u2717] Empty chat message');
+            return false;
         }
-        // Setter natif compatible React
+        // The chat textarea is only mounted while the chat panel is open.
+        const closed = document.querySelector('[data-attr="controls-chat-closed"]');
+        if (closed) {
+            closed.click();
+        }
+        let textarea;
+        try {
+            textarea = await this.waitForElement('textarea', { visible: true }, 5000);
+        } catch (e) {
+            console.error('[\u2717] Chat textarea not reachable');
+            return false;
+        }
+        // Native setter, so that React registers the new value
         const nativeSetter = Object.getOwnPropertyDescriptor(
             window.HTMLTextAreaElement.prototype,
             'value'
         ).set;
         nativeSetter.call(textarea, message);
-        // Events React
         textarea.dispatchEvent(new Event('input', { bubbles: true }));
-
-        textarea.dispatchEvent(new KeyboardEvent('keydown', {
-            key: 'Enter',
-            code: 'Enter',
-            keyCode: 13,
-            which: 13,
-            bubbles: true
-        }));
+        // The send button stays disabled until React has re-rendered.
+        const sendButton = textarea.parentElement.querySelector('button');
+        if (!sendButton) {
+            console.error('[\u2717] Chat send button not found');
+            return false;
+        }
+        const start = Date.now();
+        while (sendButton.disabled) {
+            if (Date.now() - start > 5000) {
+                console.error('[\u2717] Chat send button stayed disabled');
+                return false;
+            }
+            await new Promise(r => setTimeout(r, 50));
+        }
+        sendButton.click();
+        return true;
     }
     async leave() {
         console.log('[INFO] Leave the meeting room');


### PR DESCRIPTION
The chat message went through a FIFO in the gateway container. The
reader only kept it open for the 10 ms of a select() call, once per
iteration of a loop that also performs Selenium round trips, so a
message written outside that window was lost. The command answered
200 OK either way, and answered 200 OK as well when the FIFO did not
exist at all, since the write was guarded by a test on its presence.

sendChat now calls window.meeting.sendChat() in the browser session,
like slideShot, microphone and reaction already do, and reports an
error when the connector returns false.

Depends on the connector fix: without it, sendChat fails whenever the
chat panel is closed, whatever the transport.