### PR TITLE
[Fixed] remove the dead chat FIFO from the session loop

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -459,12 +459,15 @@ class DockerGateway:
                 out, err = res.communicate()
         elif payload['command'] == 'sendChat':
             msg = payload['param1']
-            gwSubProc = ['docker', 'exec', gwName,
-                            'sh', '-c',
-                            ('if [ -p ./chatFifo ]; then '
-                             'printf "%s\n" "{}" > ./chatFifo; fi'.format(msg))]
-            res = subprocess.Popen(gwSubProc, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out, err = res.communicate()
+            ok = self.executeInExistingChromeSession(
+                gwId,
+                "return (window.meeting && window.meeting.sendChat) ? "
+                "window.meeting.sendChat(arguments[0]) : false;",
+                msg
+            )
+            if not ok:
+                raise ValueError("sendChat failed or not supported by this connector")
+            return {"ack": True, "sendChat": True}
         elif payload['command'] == 'endCall':
             gwSubProc = ['docker', 'exec', gwName,
                             'sh', '-c',

--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -190,27 +190,46 @@ class Visio extends UIHelper{
             setTimeout(() => clearInterval(interval), 5000);
         }
     }
-    sendChat(message) {
-        const textarea = document.querySelector('textarea');
-        if (!textarea) {
-            return;
+    async sendChat(message) {
+        if (!message || !String(message).trim()) {
+            console.error('[\u2717] Empty chat message');
+            return false;
         }
-        // Setter natif compatible React
+        // The chat textarea is only mounted while the chat panel is open.
+        const closed = document.querySelector('[data-attr="controls-chat-closed"]');
+        if (closed) {
+            closed.click();
+        }
+        let textarea;
+        try {
+            textarea = await this.waitForElement('textarea', { visible: true }, 5000);
+        } catch (e) {
+            console.error('[\u2717] Chat textarea not reachable');
+            return false;
+        }
+        // Native setter, so that React registers the new value
         const nativeSetter = Object.getOwnPropertyDescriptor(
             window.HTMLTextAreaElement.prototype,
             'value'
         ).set;
         nativeSetter.call(textarea, message);
-        // Events React
         textarea.dispatchEvent(new Event('input', { bubbles: true }));
-
-        textarea.dispatchEvent(new KeyboardEvent('keydown', {
-            key: 'Enter',
-            code: 'Enter',
-            keyCode: 13,
-            which: 13,
-            bubbles: true
-        }));
+        // The send button stays disabled until React has re-rendered.
+        const sendButton = textarea.parentElement.querySelector('button');
+        if (!sendButton) {
+            console.error('[\u2717] Chat send button not found');
+            return false;
+        }
+        const start = Date.now();
+        while (sendButton.disabled) {
+            if (Date.now() - start > 5000) {
+                console.error('[\u2717] Chat send button stayed disabled');
+                return false;
+            }
+            await new Promise(r => setTimeout(r, 50));
+        }
+        sendButton.click();
+        return true;
     }
     async leave() {
         console.log('[INFO] Leave the meeting room');

--- a/src/browsing.py
+++ b/src/browsing.py
@@ -2,7 +2,6 @@
 
 import sys
 import os
-import select
 import traceback
 import queue
 import base64
@@ -33,9 +32,6 @@ class Browsing:
         if os.environ.get('AUDIO_ONLY') == "true":
             self.chromeOptions.add_argument('--headless=new')
             self.chromeOptions.add_argument('--use-fake-ui-for-media-stream')
-        self.chatFifo = "./chatFifo"
-        if not os.path.exists(self.chatFifo):
-            os.mkfifo(self.chatFifo)
         self.driver = None
         self.initScript = "window.meeting = new window.Browsing('{}', '{}', '{}', '{}', '{}', '{}')".format(
                                                     self.room['config']['webrtc_domain'],
@@ -121,23 +117,6 @@ class Browsing:
     def browse(self):
         pass
 
-    def chatHandler(self, timeout):
-        fd = os.open(self.chatFifo, os.O_RDONLY | os.O_NONBLOCK)
-        try:
-            ready, _, _ = select.select([fd], [], [], timeout)
-            if not ready:
-                raise TimeoutError()
-            data = os.read(fd, 4096)
-            if data:
-                self.driver.execute_script(
-                    "window.meeting.sendChat(arguments[0]);",
-                    data.decode().strip()
-                )
-                self.driver.execute_script("window.meeting.sendChat({});".format(json.dumps(data.strip())))
-        finally:
-            os.close(fd)
-            return
-
     def interact(self):
         try:
             inKey = self.userInputs.get(True, 0.02)
@@ -181,7 +160,6 @@ class Browsing:
             while self.room:
                 self.interact()
                 self.readPairingCode(self.driver)
-                self.chatHandler(0.01)
         except Exception as e:
             print("Error while browsing: {}".format(e), flush=True)
 


### PR DESCRIPTION
The FIFO channel is no longer used: sendChat now calls the connector
directly through the browser session.

Removing chatHandler from the loop also fixes an unrelated failure.
Googlemeet, Livekit and Nextcloud override chatHandler(self) with no
argument, while the loop called self.chatHandler(0.01). On these three
connectors the call raised a TypeError on the first iteration, which
propagated out of the loop's single try block and stopped interact()
and readPairingCode() for the rest of the call: no DTMF menu and no
pairing code refresh. Shown by inspecting the signatures rather than
observed in production, as the connectors currently fail earlier, at
join time.

The three overrides become dead code. They are left untouched to keep
this change minimal; tell me if you would rather have them removed.

The select import is dropped, it had no other use.