### PR TITLE
[Added] hang up when Visio evicts the gateway from the conference

### DIFF
--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -231,6 +231,11 @@ class Visio extends UIHelper{
         sendButton.click();
         return true;
     }
+    hasLeft() {
+        // Visio redirects to /feedback once the participant is out of the
+        // conference, including when it evicts an idle one.
+        return window.location.pathname.startsWith('/feedback');
+    }
     async leave() {
         console.log('[INFO] Leave the meeting room');
         try {

--- a/src/browsing.py
+++ b/src/browsing.py
@@ -114,6 +114,24 @@ class Browsing:
         thread.start()
         return thread
 
+    def monitorLeftMeeting(self, checkInterval=60):
+        def checkLoop():
+            while True:
+                try:
+                    left = self.driver.execute_script(
+                        "return ('hasLeft' in window.meeting) ? window.meeting.hasLeft() : null")
+                except Exception:
+                    return
+                if left is None:
+                    return
+                if left:
+                    print("Gateway is no longer in the conference, hanging up.", flush=True)
+                    subprocess.run(['echo "/hangup" | netcat -q 1 127.0.0.1 5555'], shell=True)
+                    return
+                time.sleep(checkInterval)
+        thread = threading.Thread(target=checkLoop, daemon=True)
+        thread.start()
+        return thread
     def browse(self):
         pass
 
@@ -140,6 +158,7 @@ class Browsing:
                 if joined:
                     break
                 self.interact()
+            self.monitorLeftMeeting()
             if os.getenv("ENDING_TIMEOUT"):
                 self.monitorSingleParticipant(int(os.getenv("ENDING_TIMEOUT")), checkInterval=60)
             self.loadImages(os.path.join(os.path.dirname(os.path.normpath(__file__)),'../browsing/assets/'),


### PR DESCRIPTION
Visio ends an idle conference by asking the participant whether it is still there, then redirecting it to /feedback. The gateway stayed on that page with the SIP call up: the room faced a rating form, and the gateway remained allocated until someone hung up manually.

visio.js exposes hasLeft(), true once the browser has been redirected to /feedback. browsing.py polls it every 60 s in a daemon thread, on the same pattern as monitorSingleParticipant, and sends /hangup to baresip when it turns true.

The thread starts unconditionally but exits at once when the connector does not implement hasLeft(), so the other connectors are unaffected.

Tested against a Visio conference: the gateway hangs up within a minute of the eviction and the container stops.