### PR TITLE
[Added] scale_method buffer|floor for the scaler

### DIFF
--- a/deploy/scaler/config/scaler.json
+++ b/deploy/scaler/config/scaler.json
@@ -32,6 +32,7 @@
     "assets_url": "",
     "cleaner_blacklist": [],
     "api_token": "1234",
+    "scale_method": "buffer",
     "cleanup_threshold_seconds": 600
 }
 

--- a/deploy/scaler/config/scaler.json
+++ b/deploy/scaler/config/scaler.json
@@ -32,7 +32,6 @@
     "assets_url": "",
     "cleaner_blacklist": [],
     "api_token": "1234",
-    "scale_method": "buffer",
     "cleanup_threshold_seconds": 600
 }
 

--- a/deploy/scaler/scaler.md
+++ b/deploy/scaler/scaler.md
@@ -32,6 +32,7 @@ Example configuration (JSON)
     "root_password": "secret"
   },
   "cpu_per_gw": 4,
+  "scale_method": "buffer",
   "auto_scale_threshold": {
     "default": {
       "00:00:00": {"unlockedMin": 2, "loadMax": 0.7},
@@ -58,6 +59,7 @@ Public methods
   - Destroy instances marked to_stop=1 and remove instances without a public IP after a timeout.
 - scale(scaleTime=None, incallsNum=None)
   - Compute current and target capacity using database queries and thresholds, then call upScale/downScale.
+  - `scale_method` in the JSON config selects the formula (`buffer` by default, which is the historical behaviour; `floor` uses a minimum total GW count).
 
 Important notes and known issues
 - configure currently opens files without using a context manager — consider with open(...) for safety.

--- a/deploy/scaler/scaler.md
+++ b/deploy/scaler/scaler.md
@@ -32,11 +32,10 @@ Example configuration (JSON)
     "root_password": "secret"
   },
   "cpu_per_gw": 4,
-  "scale_method": "buffer",
   "auto_scale_threshold": {
     "default": {
       "00:00:00": {"unlockedMin": 2, "loadMax": 0.7},
-      "08:00:00": {"unlockedMin": 10, "loadMax": 0.75}
+      "08:00:00": {"unlockedMin": 10, "minGw": 4, "loadMax": 0.75}
     },
     "saturday": {
       "00:00:00": {"unlockedMin": 1, "maxGw": 1, "loadMax": 1.0}
@@ -59,7 +58,9 @@ Public methods
   - Destroy instances marked to_stop=1 and remove instances without a public IP after a timeout.
 - scale(scaleTime=None, incallsNum=None)
   - Compute current and target capacity using database queries and thresholds, then call upScale/downScale.
-  - `scale_method` in the JSON config selects the formula (`buffer` by default, which is the historical behaviour; `floor` uses a minimum total GW count).
+  - Each time slot accepts two optional minimums, both honoured in the same target:
+    `unlockedMin` (minimum number of ready/idle GWs) and `minGw` (floor on the total
+    number of GWs). Omitting them means 0, which keeps the historical behaviour.
 
 Important notes and known issues
 - configure currently opens files without using a context manager — consider with open(...) for safety.

--- a/deploy/scaler/src/Scaler.py
+++ b/deploy/scaler/src/Scaler.py
@@ -59,18 +59,8 @@ class Scaler:
     def getReadyToRunCapacity(self):
         pass
 
-    def _scaleMethod(self):
-        method = self.config.get('scale_method') or 'buffer'
-        if isinstance(method, str):
-            method = method.strip().lower()
-        else:
-            method = 'buffer'
-        if method not in ('buffer', 'floor'):
-            print('Unknown scale_method={}, using buffer'.format(method), flush=True)
-            return 'buffer'
-        return method
-
-    def _currentSlot(self, scaleTime=None):
+    # Scaling logic based on current load and time of the day
+    def scale(self, scaleTime=None, incallsNum=None):
         weekday = dt.datetime.now().strftime('%A').lower()  # e.g. 'monday', 'saturday'
         thresholdConfig = self.config['auto_scale_threshold']
         if weekday in thresholdConfig:
@@ -82,33 +72,19 @@ class Scaler:
             scaleTime = dt.datetime.now().strftime("%H:%M:%S")
         th = min([ i for i in list(thresholdTimeLine.keys()) if i <= scaleTime],
                 key=lambda x:abs(getSeconds(x)-getSeconds(scaleTime)))
-        return thresholdTimeLine, th, scaleTime
-
-    # Scaling logic based on current load and time of the day
-    def scale(self, scaleTime=None, incallsNum=None):
-        if self._scaleMethod() == 'floor':
-            return self._scaleFloor(scaleTime, incallsNum)
-        return self._scaleBuffer(scaleTime, incallsNum)
-
-    def _scaleBuffer(self, scaleTime=None, incallsNum=None):
-        # unlockedMin is a buffer of ready (idle) gateways — historical formula.
-        thresholdTimeLine, th, scaleTime = self._currentSlot(scaleTime)
 
         # Get current capacity and ready to run capacity
         currentCapacity = self.getCurrentCapacity()
         readyToRunNum  = self.getReadyToRunCapacity()
 
+        # 'unlockedMin' is a buffer of ready (idle) gateways, 'minGw' a floor on
+        # the total number of gateways. Both are optional and both are honoured,
+        # so a time slot can ask for a floor, a buffer, or the two combined.
+        unlockedMin = thresholdTimeLine[th].get('unlockedMin', 0)
+        minGw = thresholdTimeLine[th].get('minGw', 0)
 
         inCallNum = incallsNum if incallsNum else (currentCapacity - readyToRunNum )
-        minCapacity = thresholdTimeLine[th]['unlockedMin'] + inCallNum
-        if readyToRunNum < thresholdTimeLine[th]['unlockedMin']:
-            targetCapacity = min((currentCapacity + thresholdTimeLine[th]['unlockedMin']
-                                  - readyToRunNum),
-                                  thresholdTimeLine[th]['maxGw'])
-            capacityIncrease = math.ceil(targetCapacity - currentCapacity)
-            if capacityIncrease > 0:
-                self.upScale(math.ceil(capacityIncrease*self.config['cpu_per_gw']))
-                currentCapacity = currentCapacity + capacityIncrease
+        minCapacity = max(minGw, unlockedMin + inCallNum)
 
         targetCapacity = min(thresholdTimeLine[th]['maxGw'],
                              max(minCapacity, inCallNum/thresholdTimeLine[th]['loadMax']))
@@ -120,40 +96,4 @@ class Scaler:
         if capacityIncrease < 0:
             # Downscale
             self.downScale(abs(capacityIncrease))
-        return 0
-
-    def _scaleFloor(self, scaleTime=None, incallsNum=None):
-        # unlockedMin is a floor on total gateway count.
-        thresholdTimeLine, th, scaleTime = self._currentSlot(scaleTime)
-        unlockedMin = thresholdTimeLine[th]['unlockedMin']
-        loadMax = thresholdTimeLine[th]['loadMax']
-        maxGw = thresholdTimeLine[th]['maxGw']
-
-        currentCapacity = self.getCurrentCapacity()
-        readyToRunNum = self.getReadyToRunCapacity()
-        inCallNum = incallsNum if incallsNum else (currentCapacity - readyToRunNum)
-        loadRatio = (inCallNum / currentCapacity) if currentCapacity > 0 else 0.0
-
-        if currentCapacity < unlockedMin:
-            floorTarget = min(unlockedMin, maxGw)
-            capacityIncrease = math.ceil(floorTarget - currentCapacity)
-            if capacityIncrease > 0:
-                self.upScale(math.ceil(capacityIncrease*self.config['cpu_per_gw']))
-                currentCapacity = currentCapacity + capacityIncrease
-
-        if currentCapacity > 0 and loadRatio > loadMax:
-            loadTarget = min(maxGw, math.ceil(inCallNum / loadMax))
-            capacityIncrease = math.ceil(loadTarget - currentCapacity)
-            if capacityIncrease > 0:
-                self.upScale(math.ceil(capacityIncrease*self.config['cpu_per_gw']))
-                currentCapacity = currentCapacity + capacityIncrease
-
-        if inCallNum > 0:
-            sustainTarget = max(unlockedMin, math.ceil(inCallNum / loadMax))
-        else:
-            sustainTarget = unlockedMin
-        sustainTarget = min(sustainTarget, maxGw)
-        capacityDecrease = currentCapacity - sustainTarget
-        if capacityDecrease > 0:
-            self.downScale(capacityDecrease)
         return 0

--- a/deploy/scaler/src/Scaler.py
+++ b/deploy/scaler/src/Scaler.py
@@ -59,8 +59,18 @@ class Scaler:
     def getReadyToRunCapacity(self):
         pass
 
-    # Scaling logic based on current load and time of the day
-    def scale(self, scaleTime=None, incallsNum=None):
+    def _scaleMethod(self):
+        method = self.config.get('scale_method') or 'buffer'
+        if isinstance(method, str):
+            method = method.strip().lower()
+        else:
+            method = 'buffer'
+        if method not in ('buffer', 'floor'):
+            print('Unknown scale_method={}, using buffer'.format(method), flush=True)
+            return 'buffer'
+        return method
+
+    def _currentSlot(self, scaleTime=None):
         weekday = dt.datetime.now().strftime('%A').lower()  # e.g. 'monday', 'saturday'
         thresholdConfig = self.config['auto_scale_threshold']
         if weekday in thresholdConfig:
@@ -72,6 +82,17 @@ class Scaler:
             scaleTime = dt.datetime.now().strftime("%H:%M:%S")
         th = min([ i for i in list(thresholdTimeLine.keys()) if i <= scaleTime],
                 key=lambda x:abs(getSeconds(x)-getSeconds(scaleTime)))
+        return thresholdTimeLine, th, scaleTime
+
+    # Scaling logic based on current load and time of the day
+    def scale(self, scaleTime=None, incallsNum=None):
+        if self._scaleMethod() == 'floor':
+            return self._scaleFloor(scaleTime, incallsNum)
+        return self._scaleBuffer(scaleTime, incallsNum)
+
+    def _scaleBuffer(self, scaleTime=None, incallsNum=None):
+        # unlockedMin is a buffer of ready (idle) gateways — historical formula.
+        thresholdTimeLine, th, scaleTime = self._currentSlot(scaleTime)
 
         # Get current capacity and ready to run capacity
         currentCapacity = self.getCurrentCapacity()
@@ -99,4 +120,40 @@ class Scaler:
         if capacityIncrease < 0:
             # Downscale
             self.downScale(abs(capacityIncrease))
+        return 0
+
+    def _scaleFloor(self, scaleTime=None, incallsNum=None):
+        # unlockedMin is a floor on total gateway count.
+        thresholdTimeLine, th, scaleTime = self._currentSlot(scaleTime)
+        unlockedMin = thresholdTimeLine[th]['unlockedMin']
+        loadMax = thresholdTimeLine[th]['loadMax']
+        maxGw = thresholdTimeLine[th]['maxGw']
+
+        currentCapacity = self.getCurrentCapacity()
+        readyToRunNum = self.getReadyToRunCapacity()
+        inCallNum = incallsNum if incallsNum else (currentCapacity - readyToRunNum)
+        loadRatio = (inCallNum / currentCapacity) if currentCapacity > 0 else 0.0
+
+        if currentCapacity < unlockedMin:
+            floorTarget = min(unlockedMin, maxGw)
+            capacityIncrease = math.ceil(floorTarget - currentCapacity)
+            if capacityIncrease > 0:
+                self.upScale(math.ceil(capacityIncrease*self.config['cpu_per_gw']))
+                currentCapacity = currentCapacity + capacityIncrease
+
+        if currentCapacity > 0 and loadRatio > loadMax:
+            loadTarget = min(maxGw, math.ceil(inCallNum / loadMax))
+            capacityIncrease = math.ceil(loadTarget - currentCapacity)
+            if capacityIncrease > 0:
+                self.upScale(math.ceil(capacityIncrease*self.config['cpu_per_gw']))
+                currentCapacity = currentCapacity + capacityIncrease
+
+        if inCallNum > 0:
+            sustainTarget = max(unlockedMin, math.ceil(inCallNum / loadMax))
+        else:
+            sustainTarget = unlockedMin
+        sustainTarget = min(sustainTarget, maxGw)
+        capacityDecrease = currentCapacity - sustainTarget
+        if capacityDecrease > 0:
+            self.downScale(capacityDecrease)
         return 0

--- a/docs/scaler_logic.md
+++ b/docs/scaler_logic.md
@@ -31,11 +31,14 @@ The scaling behavior is driven by thresholds defined in `scaler.json`, configura
 
 | Parameter       | Description                                                                 |
 |----------------|-----------------------------------------------------------------------------|
-| `unlockedMin`   | Minimum number of **available** gateways before triggering scale-up         |
+| `scale_method`  | `buffer` (default, historical) or `floor`. Omitted key means `buffer`.      |
+| `unlockedMin`   | **buffer:** min **available** GWs. **floor:** min **total** GW count.       |
 | `loadMax`       | Maximum allowed **usage ratio** (`busy / registered`) before scaling occurs |
 | `cpu_per_gw`    | Number of vCPUs assigned per SIPMediaGW instance (typically 4)              |
 
 ---
+
+With `scale_method` omitted or set to `buffer`, the decision flow below is unchanged. With `"scale_method": "floor"`, `unlockedMin` is a floor on **total** capacity: restore that floor, scale up if `busy/registered > loadMax`, then release surplus down to `max(unlockedMin, ceil(busy / loadMax))` (capped by `maxGw`).
 
 ##  Decision Flow
 

--- a/docs/scaler_logic.md
+++ b/docs/scaler_logic.md
@@ -31,20 +31,23 @@ The scaling behavior is driven by thresholds defined in `scaler.json`, configura
 
 | Parameter       | Description                                                                 |
 |----------------|-----------------------------------------------------------------------------|
-| `scale_method`  | `buffer` (default, historical) or `floor`. Omitted key means `buffer`.      |
-| `unlockedMin`   | **buffer:** min **available** GWs. **floor:** min **total** GW count.       |
+| `unlockedMin`   | Minimum number of **available** gateways to keep as an idle buffer          |
+| `minGw`         | Floor on the **total** number of gateways, whatever the load                |
 | `loadMax`       | Maximum allowed **usage ratio** (`busy / registered`) before scaling occurs |
 | `cpu_per_gw`    | Number of vCPUs assigned per SIPMediaGW instance (typically 4)              |
 
----
+`unlockedMin` and `minGw` are both optional and are expressed per time slot. An
+omitted key counts as `0`, so a configuration that only sets `unlockedMin` keeps
+the historical behaviour. Setting both is allowed: the target capacity satisfies
+whichever is the more demanding at that moment.
 
-With `scale_method` omitted or set to `buffer`, the decision flow below is unchanged. With `"scale_method": "floor"`, `unlockedMin` is a floor on **total** capacity: restore that floor, scale up if `busy/registered > loadMax`, then release surplus down to `max(unlockedMin, ceil(busy / loadMax))` (capped by `maxGw`).
+---
 
 ##  Decision Flow
 
 | Decision Steps | Diagram |
 |----------------|---------|
-|**1. Collect current metrics**: `available`, `busy`, `registered`<br><br>**2. Ensure Minimum Availability Buffer**<br>- If `available < unlockedMin`, upscale to restore buffer.<br><br>**3. Compute Minimum Required Capacity**<br>- `minCapacity = busy + unlockedMin`<br><br>**4. Determine Target Capacity**<br>- `targetCapacity = max(minCapacity, busy / loadMax)`<br><br>**5. Adjust Deployment Accordingly**<br>- If `targetCapacity > available`: upscale<br>- If `targetCapacity < available`: downscale  | <img src="sipmediagw_autoscaling_logic.png" width=50% height=100%> |
+|**1. Collect current metrics**: `available`, `busy`, `registered`<br><br>**2. Compute Minimum Required Capacity**<br>- `minCapacity = max(minGw, busy + unlockedMin)`<br><br>**3. Determine Target Capacity**<br>- `targetCapacity = min(maxGw, max(minCapacity, busy / loadMax))`<br><br>**4. Adjust Deployment Accordingly**<br>- If `targetCapacity > registered`: upscale<br>- If `targetCapacity < registered`: downscale  | <img src="sipmediagw_autoscaling_logic.png" width=50% height=100%> |
 
 ---
 
@@ -83,7 +86,16 @@ With `scale_method` omitted or set to `buffer`, the decision flow below is uncha
 
 ---
 
-### 🧯 Case 4: Instance Not Registered
+### 🏗️ Case 4: Floor Enforced by `minGw`
+- `registered = 1`, `busy = 0`, `available = 1`
+- `unlockedMin = 0`, `minGw = 3`, `loadMax = 0.7`
+- No call, so the buffer asks for nothing, but the floor does
+- `minCapacity = max(3, 0 + 0) = 3` → scale up by 2 instances
+- With `unlockedMin = 2` on top: `minCapacity = max(3, 2 + 0) = 3`, same target
+
+---
+
+### 🧯 Case 5: Instance Not Registered
 - A new SIPMediaGW VM is deployed but not registered in Kamailio within 10 minutes
 - It is considered broken and deleted automatically
 - Ensures resilience and self-healing behavior


### PR DESCRIPTION
## Summary
- Add optional `scale_method` in `scaler.json`: `buffer` (default) or `floor`.
- `buffer` is the current main formula: `unlockedMin` is a minimum number of *ready* (idle) gateways.
- `floor` is opt-in: `unlockedMin` is a floor on *total* gateway count (restore floor, scale on load, then release surplus, capped by `maxGw`).
- If `scale_method` is omitted, behaviour is unchanged (`buffer`).