### PR TITLE
[Added] expose Visio publish permissions in mediaState

### DIFF
--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -99,9 +99,17 @@ class Visio extends UIHelper{
             console.error('[✗] media-state element not found');
             return null;
         }
+        // Publish permissions are optional: they are only exposed by Visio
+        // instances that carry the can-publish attributes. Undefined is
+        // reported as null so that a client can tell "not allowed to publish"
+        // from "this instance does not say", instead of assuming the former.
+        const canPublish = (value) =>
+            value === undefined ? null : value === 'true';
         return {
             microphone: el.dataset.microphoneEnabled === 'true',
-            camera: el.dataset.cameraEnabled === 'true'
+            camera: el.dataset.cameraEnabled === 'true',
+            canPublishMicrophone: canPublish(el.dataset.canPublishMicrophone),
+            canPublishCamera: canPublish(el.dataset.canPublishCamera)
         };
     }
     microphone(param) {


### PR DESCRIPTION
Follow-up to the DINUM PR that adds data-can-publish-microphone and data-can-publish-camera to MediaStateObserver (merged in suitenumerique/meet). This side can be merged before the attributes reach production: mediaState() reports null until the instance exposes them, and the existing fields are unaffected.

Visio exposes data-can-publish-microphone and data-can-publish-camera on the #media-state element, alongside the enabled state. They tell whether the participant is allowed to publish at all: when the host turns off "Allumer le micro", the gateway can no longer unmute, microphone(on) returns without effect, and nothing lets a client know.

mediaState() now reports them. A missing attribute yields null rather than false, so a client can tell "not allowed to publish" from "this instance does not expose it" instead of assuming the former and disabling a control that actually works.

This keeps the gateway working against Visio instances that predate the attributes: the existing microphone and camera fields are unchanged.

Tested against a Visio conference: null when the attributes are absent, false and true once they are set.