### PR TITLE
[Added] OpenStack provider and ManageInstance ABC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ logs/
 .ruff_cache/
 .vscode/
 browsing/assets/config.json
+
+# Local OpenStack credentials (keep *.json.example committed)
+deploy/scaler/src/providers/openstackProvider/config/sipmediagw.json

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -116,6 +116,7 @@ services:
     volumes:
       - ./scaler/config:/var/config
       - ./scaler/outscale/config:/var/outscale/config
+      - ./scaler/src/providers/openstackProvider/:/var/providers/openstackProvider
     network_mode: host
     logging:
       driver: syslog
@@ -127,6 +128,8 @@ services:
     environment:
       TZ: "Europe/Paris" # Time Zone
       SCALER_CONFIG_FILE: "scaler.json"
+      # Outscale (default). For OpenStack: CSP_NAME=openstackProvider,
+      # CSP_CONFIG_FILE=sipmediagw.json, CSP_PROFILE=<profile in that file>.
       CSP_NAME: "outscale"
       CSP_CONFIG_FILE: "sipmediagw_staging.json"
       CSP_PROFILE: "visio-dev"

--- a/deploy/scaler/Dockerfile
+++ b/deploy/scaler/Dockerfile
@@ -7,7 +7,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install --upgrade setuptools
 RUN pip3 install requests httplib2 web.py mysql-connector-python \
                  defusedxml fire xmltodict typing_extensions \
-                 python-dateutil redis
+                 python-dateutil redis openstacksdk
 
 COPY src/ /var
 WORKDIR /var

--- a/deploy/scaler/scaler.md
+++ b/deploy/scaler/scaler.md
@@ -13,11 +13,10 @@ Prerequisites
 - Python packages: mysql-connector-python, python-dateutil
 - Network access to the Kamailio database
 - A Redis server for Media scaler
-- A CSP object implementing:
-  - instType (dict of instance sizes)
-  - createInstance(type, name_prefix)
-  - destroyInstances(list_of_ips)
-  - enumerateInstances()
+- A CSP object implementing ManageInstance (`src/manageInstance.py`):
+  - configureInstance, enumerateInstances, createInstance, destroyInstances
+  - Optional overrides: createInstancesParallel, reconcile, close
+- Providers: Outscale (`CSP_NAME=outscale`) or OpenStack (`CSP_NAME=openstackProvider`)
 
 Location
 - Source: deploy/scaler/Scaler.py
@@ -74,6 +73,17 @@ Recommended improvements
 - Handle empty instType (cpuRange) in upScale.
 - Refactor SQL queries to avoid fragile concatenation and improve clarity.
 - Add unit tests for capacity calculation and scaling decisions.
+
+OpenStack provider
+- Package: `src/providers/openstackProvider/` (provider, networking, volumes, errors).
+- Copy `config/sipmediagw.json.example` to `sipmediagw.json` (gitignored) and fill credentials.
+- Set `CSP_NAME=openstackProvider`, `CSP_CONFIG_FILE=sipmediagw.json`, `CSP_PROFILE` to a key under `profile`.
+- `initData["gw_name_prefix"]` (from `scaler.json`) is required: only servers named
+  `<provider name>.<gw_name_prefix>...` are managed (fail-closed if missing).
+- `createInstance` waits for a public IP (manual `?up`). Batch create is available on
+  the provider as `createInstancesParallel`; `reconcile()` attaches missing floating
+  IPs and drops `ERROR` / stuck `BUILD` servers. The default `scale()` path still
+  calls `createInstance` one by one.
 
 Contact
 - Refer to the repo owner or infra team for implementation-specific questions.

--- a/deploy/scaler/src/Scaler.py
+++ b/deploy/scaler/src/Scaler.py
@@ -18,6 +18,10 @@ class Scaler:
         self.config = json.load(f)
         f.close()
 
+    def reconcile(self):
+        # Let the provider settle in-flight work (no-op unless it overrides).
+        self.csp.reconcile()
+
     # Upscale function
     def upScale(self, numCPU):
         # cpuRange values must be multiples of 4

--- a/deploy/scaler/src/manageInstance.py
+++ b/deploy/scaler/src/manageInstance.py
@@ -1,28 +1,88 @@
 #!/usr/bin/env python
+"""Contract between the scaler and the cloud provider it drives."""
 
-import sys
-import os
-import time
-import traceback
-import queue
+import logging
+from abc import ABC, abstractmethod
 
-class ManageInstance:
+logger = logging.getLogger(__name__)
 
-    def __init__(self):
-        pass
 
-    def configureInstance(self, configFile):
-        pass
+class ManageInstance(ABC):
+    """
+    Interface a cloud provider must satisfy to be usable by the scaler.
 
+    The four abstract methods have to be implemented; a provider that misses
+    one cannot be instantiated at all, which surfaces the gap at startup
+    instead of on the first scaling iteration. `createInstancesParallel` and
+    `close` ship with working defaults, so a provider only overrides them when
+    it has something better to offer than the generic behaviour.
+    """
+
+    @abstractmethod
+    def configureInstance(self, configFile, initData):
+        """
+        Load the provider configuration from `configFile`.
+
+        `initData` carries the per-scaler-type data injected into the instances
+        at boot, keyed by scaler type ("sip" or "media").
+        """
+
+    @abstractmethod
     def enumerateInstances(self):
-        pass
+        """
+        Return the instances managed by this provider.
 
-    def createInstance(self, numCPU, gigaRAM="4", name=None, ip=None):
-        pass
+        Each entry is a dict shaped as follows, which is what `Scaler.cleanup`
+        expects:
 
+            {
+                "start": "<ISO-8601 creation date>",
+                "addr": {"priv": "<private ip>", "pub": "<public ip or None>"},
+                "cpu_count": <int>,
+            }
+        """
+
+    @abstractmethod
+    def createInstance(self, numCPU, gigaRAM, name=None, ip=None):
+        """
+        Create a single instance and return a dict describing it.
+
+        `ip` requests a specific public address; when it is None the provider
+        allocates one. Raises when the instance cannot be created.
+        """
+
+    @abstractmethod
     def destroyInstances(self, ipList):
-        pass
+        """Destroy the instances owning the given IP addresses."""
 
+    def createInstancesParallel(self, count, numCPU, gigaRAM, name=None,
+                                timeoutSeconds=None):
+        """
+        Create `count` instances and return those that were actually created.
 
+        The returned list is shorter than `count` when some creations failed,
+        which is how the scaler learns its real capacity gain. This default
+        creates them one after another and ignores `timeoutSeconds`, which is
+        only meaningful to providers that submit the creations concurrently.
+        """
+        created = []
+        for _ in range(max(0, int(count))):
+            try:
+                created.append(self.createInstance(numCPU, gigaRAM, name=name))
+            except Exception as error:
+                logger.error("Instance creation failed: %s", error)
+        return created
 
+    def reconcile(self, timeoutSeconds=None):
+        """
+        Bring the fleet in line with what previous creations left behind.
 
+        Called once per scaling iteration, before any decision is taken. A
+        provider that creates instances asynchronously uses this to finish the
+        job and to drop the ones that will never boot; the default does nothing,
+        which is correct for a provider whose createInstance already returns a
+        fully usable instance.
+        """
+
+    def close(self):
+        """Release the provider resources. No-op unless the provider holds any."""

--- a/deploy/scaler/src/providers/openstackProvider/__init__.py
+++ b/deploy/scaler/src/providers/openstackProvider/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+"""OpenStack provider for the SIPMediaGW scaler."""
+
+from .provider import OpenstackProvider
+
+__all__ = ["OpenstackProvider"]

--- a/deploy/scaler/src/providers/openstackProvider/config/sipmediagw.json.example
+++ b/deploy/scaler/src/providers/openstackProvider/config/sipmediagw.json.example
@@ -1,0 +1,26 @@
+{
+  "name": "GW",
+  "key_pair": "",
+  "profile": {
+    "ovh_uk": {
+      "auth_url": "",
+      "region": "",
+      "client_id": "",
+      "client_secret": ""
+    }
+  },
+  "instance_image": "",
+  "delete_volumes_on_destroy": true,
+  "interface_1": {
+    "priv": "",
+    "pub": ""
+  },
+  "instance_type_by_cpu_num": {
+    "2": { "4": "d2-4" },
+    "4": { "8": "d2-8" }
+  },
+  "security_group": {
+    "admin": "default",
+    "app": "default"
+  }
+}

--- a/deploy/scaler/src/providers/openstackProvider/errors.py
+++ b/deploy/scaler/src/providers/openstackProvider/errors.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Classification of the OpenStack errors the provider needs to react to."""
+
+import openstack.exceptions
+
+# openstacksdk renamed ResourceNotFound to NotFoundException and keeps the other
+# name as an alias, so bind whichever the installed release actually exposes.
+NOT_FOUND_EXCEPTIONS = tuple(
+    {
+        exc
+        for exc in (
+            getattr(openstack.exceptions, "NotFoundException", None),
+            getattr(openstack.exceptions, "ResourceNotFound", None),
+        )
+        if exc is not None
+    }
+)
+
+
+def isNotFoundError(exc):
+    """True when `exc` reports an HTTP 404, whichever library raised it."""
+    if NOT_FOUND_EXCEPTIONS and isinstance(exc, NOT_FOUND_EXCEPTIONS):
+        return True
+    # keystoneauth1 errors can surface unwrapped by the SDK; both libraries carry
+    # the HTTP status as an attribute, so the message never needs to be parsed.
+    status = getattr(exc, "status_code", None) or getattr(exc, "http_status", None)
+    return status == 404

--- a/deploy/scaler/src/providers/openstackProvider/networking.py
+++ b/deploy/scaler/src/providers/openstackProvider/networking.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+"""Neutron lookups shared by the OpenStack provider.
+
+Every function here is best-effort: a lookup that cannot be satisfied returns
+None rather than raising, because a configuration reference may legitimately
+designate either a subnet or a network, and callers always have a fallback.
+"""
+
+import logging
+from ipaddress import ip_address, ip_network
+
+logger = logging.getLogger(__name__)
+
+
+def isInSubnet(ipAddr, cidr):
+    """True when `ipAddr` belongs to `cidr`, False when either cannot be parsed."""
+    try:
+        return ip_address(ipAddr) in ip_network(cidr, strict=False)
+    except (ValueError, TypeError) as exc:
+        logger.debug("CIDR match failed for %s in %s: %s", ipAddr, cidr, exc)
+        return False
+
+
+def findSubnet(conn, ref):
+    """Look up a Neutron subnet by name or id, returning None when unresolvable."""
+    if not ref:
+        return None
+    try:
+        return conn.network.find_subnet(ref)
+    except Exception as exc:
+        logger.debug("Reference '%s' does not resolve to a subnet: %s", ref, exc)
+        return None
+
+
+def findNetwork(conn, ref):
+    """Look up a Neutron network by name or id, returning None when unresolvable."""
+    if not ref:
+        return None
+    try:
+        return conn.network.find_network(ref)
+    except Exception as exc:
+        logger.debug("Reference '%s' does not resolve to a network: %s", ref, exc)
+        return None
+
+
+def resolveNetworkRef(conn, ref):
+    """
+    Resolve a config reference that may designate either a subnet or a network.
+
+    Returns a (subnet, network) pair where at most one member is set: the
+    network is only looked up when the reference does not match a subnet.
+    """
+    subnet = findSubnet(conn, ref)
+    if subnet is not None:
+        return subnet, None
+    network = findNetwork(conn, ref)
+    if ref and network is None:
+        logger.warning("Reference '%s' matches no Neutron subnet nor network", ref)
+    return None, network
+
+
+def resolvePortIdForFixedIp(conn, server, fixedIp):
+    """Find the Neutron port on `server` that owns `fixedIp`, or None."""
+    if not fixedIp or not server or not getattr(server, "id", None):
+        return None
+
+    try:
+        portsIter = conn.network.ports(device_id=server.id)
+    except Exception as exc:
+        logger.warning(
+            "Cannot list ports filtered by device_id=%s, skipping port resolution: %s",
+            server.id, exc,
+        )
+        return None
+
+    try:
+        for port in portsIter:
+            for fixed in getattr(port, "fixed_ips", None) or []:
+                if isinstance(fixed, dict):
+                    ipAddr = (
+                        fixed.get("ip_address")
+                        or fixed.get("ip")
+                        or fixed.get("address")
+                    )
+                else:
+                    ipAddr = fixed
+                if ipAddr == fixedIp:
+                    return port.id
+    except Exception as exc:
+        logger.warning("Error iterating ports for server %s: %s", server.id, exc)
+
+    return None
+
+
+def extractServerIps(server, primarySubnetCidr=None, expectedNetwork=None):
+    """
+    Extract the (private, public) IP pair from a server's address map.
+
+    Nova returns addresses in an arbitrary order, so the first match is kept
+    rather than the last: a multi-NIC server must yield the same pair on every
+    call. The private IP is selected by CIDR when `primarySubnetCidr` is known,
+    and by network name otherwise.
+    """
+    privIp = None
+    pubIp = None
+
+    for netName, addrs in (server.addresses or {}).items():
+        for addr in addrs:
+            ipAddr = addr.get("addr") or addr.get("address")
+            if not ipAddr:
+                continue
+            ipType = addr.get("OS-EXT-IPS:type") or addr.get("type")
+
+            if ipType == "floating":
+                if pubIp is None:
+                    pubIp = ipAddr
+            elif ipType == "fixed" and privIp is None:
+                if primarySubnetCidr:
+                    if isInSubnet(ipAddr, primarySubnetCidr):
+                        privIp = ipAddr
+                elif not expectedNetwork or netName == expectedNetwork:
+                    privIp = ipAddr
+
+    return privIp, pubIp

--- a/deploy/scaler/src/providers/openstackProvider/provider.py
+++ b/deploy/scaler/src/providers/openstackProvider/provider.py
@@ -1,0 +1,847 @@
+#!/usr/bin/env python
+"""OpenStack implementation of the scaler's cloud provider interface."""
+
+import json
+import logging
+import time
+import datetime as dt
+from collections import defaultdict
+from ipaddress import ip_address
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import dateutil.parser as du
+import openstack
+
+from manageInstance import ManageInstance
+
+from . import networking
+from . import volumes
+
+logger = logging.getLogger(__name__)
+
+_MAX_PARALLEL_WORKERS = 10
+_DEFAULT_CREATE_TIMEOUT = 300
+_POLL_INTERVAL = 5
+
+# Statuses of a server that already counts as capacity: one that is still
+# building is on its way to becoming a gateway, and the scaler has to know about
+# it or it would order the very same instance again on the next iteration.
+_COUNTED_STATUSES = ("ACTIVE", "BUILD")
+
+
+class OpenstackProvider(ManageInstance):
+
+    def __init__(self, profile):
+        self.profile = profile
+        self.conn = None
+        self.instName = None
+        self.gwNamePrefix = None
+        self._warnedMissingInstName = False
+        self.instType = {}
+        self.ami = None
+        self.network = None
+        self.subnet = None
+        self._primarySubnetCidr = None
+        # Interface selection for the "primary" NIC.
+        # Values can be either Neutron network names or subnet names.
+        # If `interface_1.priv` is set -> VM fixed IP comes from this.
+        # If `interface_1.pub` is set -> floating IP is allocated from this.
+        self.interface1PubRef = None
+        self.interface1PrivRef = None
+        self.secuGrp = {}
+        self.keyPair = None
+        self.userData = ""
+        self._flavorVcpuCache = {}
+        self.deleteVolumesOnDestroy = False
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    def _connect(self, profileCfg):
+        cfg = profileCfg if profileCfg else {}
+
+        if cfg.get("client_id") and cfg.get("client_secret"):
+            return openstack.connection.Connection(
+                auth={
+                    "auth_url": cfg.get("auth_url"),
+                    "application_credential_id": cfg.get("client_id"),
+                    "application_credential_secret": cfg.get("client_secret"),
+                },
+                auth_type="v3applicationcredential",
+                region_name=cfg.get("region"),
+                identity_interface=cfg.get("interface", "public"),
+            )
+
+        auth = {}
+        for key in [
+            "auth_url",
+            "username",
+            "password",
+            "project_name",
+            "project_id",
+            "user_domain_name",
+            "user_domain_id",
+            "project_domain_name",
+            "project_domain_id",
+        ]:
+            if cfg.get(key) is not None:
+                auth[key] = cfg.get(key)
+
+        kwargs = {
+            "auth": auth if auth else None,
+            "region_name": cfg.get("region"),
+            "identity_interface": cfg.get("interface", "public"),
+        }
+        return openstack.connection.Connection(**{k: v for k, v in kwargs.items() if v is not None})
+
+    def close(self):
+        if self.conn is None:
+            return
+        try:
+            self.conn.close()
+        except Exception as exc:
+            logger.warning("Failed to close the OpenStack connection: %s", exc)
+        finally:
+            self.conn = None
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def configureInstance(self, configFile, initData):
+        with open(configFile) as f:
+            instConfig = json.load(f)
+
+        # Presence is not enough: an empty "name" would make _isManagedServer
+        # match every server in the project. Refuse blank values up front.
+        required = ["name", "instance_image", "instance_type_by_cpu_num"]
+        missing = [k for k in required if k not in instConfig]
+        if missing:
+            raise ValueError("Missing required config keys: {}".format(missing))
+
+        name = instConfig["name"]
+        image = instConfig["instance_image"]
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("'name' must be a non-empty string (instance name prefix)")
+        if not isinstance(image, str) or not image.strip():
+            raise ValueError("'instance_image' must be a non-empty string")
+        if not isinstance(instConfig["instance_type_by_cpu_num"], dict):
+            raise ValueError("'instance_type_by_cpu_num' must be a non-empty mapping")
+        if not instConfig["instance_type_by_cpu_num"]:
+            raise ValueError("'instance_type_by_cpu_num' must be a non-empty mapping")
+
+        if self.conn is None:
+            profileCfg = instConfig.get("profile", {}).get(self.profile, {})
+            self.conn = self._connect(profileCfg)
+
+        self.instName = name.strip()
+        self._warnedMissingInstName = False
+        # Narrow ownership to "<name>.<gw_name_prefix>..." (e.g. GW.mediagw-0),
+        # not every server that merely starts with "GW".
+        rawGwPrefix = initData.get("gw_name_prefix") if isinstance(initData, dict) else None
+        if isinstance(rawGwPrefix, str) and rawGwPrefix.strip():
+            self.gwNamePrefix = rawGwPrefix.strip()
+        else:
+            self.gwNamePrefix = None
+            logger.warning(
+                "gw_name_prefix missing from initData; no server will be treated as managed"
+            )
+        self.instType = instConfig["instance_type_by_cpu_num"]
+        self.ami = image.strip()
+        self.network = instConfig.get("network")
+        self.subnet = instConfig.get("subnet")
+        iface1 = instConfig.get("interface_1", {}) or {}
+        self.interface1PrivRef = iface1.get("priv") or iface1.get("priv_subnet")
+        self.interface1PubRef = iface1.get("pub") or iface1.get("pub_subnet")
+        self.secuGrp = instConfig.get("security_group", {})
+        self.keyPair = instConfig.get("key_pair")
+        self.deleteVolumesOnDestroy = bool(instConfig.get("delete_volumes_on_destroy", False))
+        self.userData = ""
+        self._primarySubnetCidr = None
+        logger.info(
+            "Volume deletion on destroy is %s",
+            "ENABLED" if self.deleteVolumesOnDestroy else "DISABLED",
+        )
+
+        self._resolvePrimarySubnetCidr()
+        self._buildUserData(instConfig, initData)
+
+    def _buildUserData(self, instConfig, initData):
+        """Render the cloud-init script from the config and the per-action data."""
+        scriptCfg = instConfig.get("user_data", {}).get("script", {})
+        self.userData = "\n".join(scriptCfg.get("common", []))
+
+        if "sip" in initData:
+            sipCfg = instConfig.get("user_data", {})
+            for initKey, cfgKey in (
+                ("registrar", "sip_registrar"),
+                ("proxy", "outbound_proxy"),
+                ("turn", "turn_server"),
+            ):
+                if initKey in initData["sip"]:
+                    continue
+                entry = sipCfg.get(cfgKey)
+                initData["sip"][initKey] = (
+                    (entry.get("priv") or entry.get("pub")) if entry else None
+                )
+
+        for act in initData:
+            if not isinstance(initData.get(act), dict):
+                continue
+            actionScript = scriptCfg.get(act, [])
+            if not actionScript:
+                continue
+            self.userData += "\n"
+            try:
+                self.userData += "\n".join(actionScript).format_map(
+                    defaultdict(str, initData[act])
+                )
+            except (KeyError, ValueError, IndexError) as exc:
+                logger.error(
+                    "Failed to render user_data script for action '%s': %s", act, exc
+                )
+                raise
+
+    # ------------------------------------------------------------------
+    # Network resolution
+    # ------------------------------------------------------------------
+
+    def _resolvePrimarySubnetCidr(self):
+        """Best-effort: derive the subnet CIDR for the primary fixed IP."""
+        primaryRef = self.interface1PrivRef or self.interface1PubRef
+        if primaryRef:
+            subnet = networking.findSubnet(self.conn, primaryRef)
+            if subnet is not None and getattr(subnet, "cidr", None):
+                self._primarySubnetCidr = subnet.cidr
+                return
+
+            if not self.network:
+                network = networking.findNetwork(self.conn, primaryRef)
+                if network is not None:
+                    self.network = getattr(network, "name", None) or primaryRef
+
+        if self._primarySubnetCidr is None and self.subnet:
+            subnet = networking.findSubnet(self.conn, self.subnet)
+            if subnet is not None and getattr(subnet, "cidr", None):
+                self._primarySubnetCidr = subnet.cidr
+
+    def _resolveFloatingNetworkId(self):
+        """Best-effort: find the Neutron network floating IPs are allocated from."""
+        if self.interface1PubRef:
+            subnet, network = networking.resolveNetworkRef(self.conn, self.interface1PubRef)
+            if subnet is not None:
+                return subnet.network_id
+            if network is not None:
+                return network.id
+
+        subnet = networking.findSubnet(self.conn, self.subnet)
+        if subnet is not None:
+            return subnet.network_id
+
+        network = networking.findNetwork(self.conn, self.network)
+        if network is not None:
+            return network.id
+
+        logger.warning(
+            "No floating IP network could be resolved from interface_1.pub='%s', "
+            "subnet='%s' or network='%s'",
+            self.interface1PubRef, self.subnet, self.network,
+        )
+        return None
+
+    def _buildPrimaryNic(self):
+        """
+        Build the NIC list for the primary interface.
+        Preference:
+          1) interface_1.priv (fixed IP)
+          2) interface_1.pub (if priv is missing)
+          3) legacy network/subnet
+        Returns a list of one OpenStack networks entry for `create_server()`.
+        """
+        primaryRef = self.interface1PrivRef or self.interface1PubRef
+
+        if primaryRef:
+            subnet, network = networking.resolveNetworkRef(self.conn, primaryRef)
+            if subnet is not None:
+                return [{"net-id": subnet.network_id, "v4-fixed-ip": None}]
+            if network is not None:
+                return [{"uuid": network.id}]
+
+        subnet = networking.findSubnet(self.conn, self.subnet)
+        if subnet is not None:
+            return [{"net-id": subnet.network_id, "v4-fixed-ip": None}]
+
+        network = networking.findNetwork(self.conn, self.network)
+        if network is not None:
+            return [{"uuid": network.id}]
+
+        return []
+
+    def _getServerIps(self, server):
+        return networking.extractServerIps(server, self._primarySubnetCidr, self.network)
+
+    # ------------------------------------------------------------------
+    # Instance enumeration
+    # ------------------------------------------------------------------
+
+    def _getServerVcpus(self, server):
+        flavorInfo = getattr(server, "flavor", None) or {}
+        if not flavorInfo:
+            return 0
+
+        # Some OpenStack versions (microversion 2.47+) embed vcpus in the
+        # server detail response, so we can skip the extra API call.
+        if flavorInfo.get("vcpus"):
+            return int(flavorInfo["vcpus"])
+
+        flavorRef = flavorInfo.get("id") or flavorInfo.get("original_name")
+        if not flavorRef:
+            return 0
+
+        if flavorRef not in self._flavorVcpuCache:
+            try:
+                flv = self.conn.compute.find_flavor(flavorRef)
+                self._flavorVcpuCache[flavorRef] = int(getattr(flv, "vcpus", 0) or 0) if flv else 0
+            except Exception as exc:
+                logger.warning("Cannot resolve vCPUs for flavor '%s': %s", flavorRef, exc)
+                self._flavorVcpuCache[flavorRef] = 0
+        return self._flavorVcpuCache[flavorRef]
+
+    @staticmethod
+    def _serverAgeSeconds(server):
+        """Seconds since the server was created, or None when Nova did not say."""
+        created = getattr(server, "created_at", None) or getattr(server, "created", None)
+        if not created:
+            return None
+        try:
+            start = du.parse(created)
+        except (ValueError, OverflowError, TypeError) as exc:
+            logger.debug("Cannot parse creation date '%s': %s", created, exc)
+            return None
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=dt.timezone.utc)
+        return (dt.datetime.now(dt.timezone.utc) - start).total_seconds()
+
+    def _managedNamePrefix(self):
+        """
+        Full name prefix of servers this scaler owns: "<instName>.<gwNamePrefix>".
+
+        Creations are named "{instName}.{gwNamePrefix}-{index}", so ownership must
+        require both parts. Matching on instName alone would also catch unrelated
+        VMs such as "GW.other".
+        """
+        if not self.instName or not self.gwNamePrefix:
+            return None
+        return "{}.{}".format(self.instName, self.gwNamePrefix)
+
+    def _isManagedServer(self, server):
+        """
+        Return True if the server was created by this scaler (name prefix match).
+
+        Fail closed when the composed prefix is unknown: matching every server in
+        the project would let cleanup or destroy touch unrelated VMs.
+        """
+        managedPrefix = self._managedNamePrefix()
+        if not managedPrefix:
+            if not getattr(self, "_warnedMissingInstName", False):
+                logger.warning(
+                    "Managed name prefix unset (name=%r gw_name_prefix=%r); "
+                    "treating no server as managed",
+                    self.instName, self.gwNamePrefix,
+                )
+                self._warnedMissingInstName = True
+            return False
+        serverName = getattr(server, "name", None) or ""
+        return serverName.startswith(managedPrefix)
+
+    def enumerateInstances(self):
+        if not self.conn:
+            return []
+
+        appSg = self.secuGrp.get("app") if isinstance(self.secuGrp, dict) else None
+        instDict = []
+        for server in self.conn.compute.servers(details=True):
+            try:
+                if (server.status or "").upper() not in _COUNTED_STATUSES:
+                    continue
+
+                if not self._isManagedServer(server):
+                    continue
+
+                if appSg:
+                    sgNames = set()
+                    for sg in server.security_groups or []:
+                        if isinstance(sg, dict):
+                            sgNames.add(sg.get("name"))
+                        else:
+                            sgNames.add(sg)
+                    if appSg not in sgNames:
+                        continue
+
+                privIp, pubIp = self._getServerIps(server)
+                startTime = getattr(server, "created_at", None) or getattr(server, "created", None)
+                cpuCnt = self._getServerVcpus(server)
+
+                instDict.append(
+                    {
+                        "start": startTime,
+                        "addr": {"priv": privIp, "pub": pubIp},
+                        "cpu_count": int(cpuCnt),
+                    }
+                )
+            except Exception as exc:
+                logger.warning("Skipping server %s during enumeration: %s", getattr(server, "id", "?"), exc)
+        return instDict
+
+    def _buildServersByIpIndex(self):
+        """Load all servers once and build an IP -> server lookup dict (managed VMs only)."""
+        index = {}
+        for server in self.conn.compute.servers(details=True):
+            if not self._isManagedServer(server):
+                continue
+            for addrs in (server.addresses or {}).values():
+                for addr in addrs:
+                    ipAddr = addr.get("addr") or addr.get("address")
+                    if ipAddr:
+                        index[ipAddr] = server
+        return index
+
+    # ------------------------------------------------------------------
+    # Floating IPs
+    # ------------------------------------------------------------------
+
+    def _allocateFloatingIp(self, server, privIp):
+        """Allocate a new floating IP and bind it to `server`. Returns it or None."""
+        fipNetId = self._resolveFloatingNetworkId()
+        if not fipNetId:
+            return None
+
+        portId = networking.resolvePortIdForFixedIp(self.conn, server, privIp)
+        if portId:
+            fip = self.conn.network.create_ip(floating_network_id=fipNetId, port_id=portId)
+            return getattr(fip, "floating_ip_address", None)
+
+        # No port resolved: allocate the address detached, then let Nova bind it.
+        fip = self.conn.network.create_ip(floating_network_id=fipNetId)
+        pubIp = getattr(fip, "floating_ip_address", None)
+        if pubIp:
+            self.conn.compute.add_floating_ip_to_server(server, pubIp)
+        return pubIp
+
+    def _attachExistingFloatingIp(self, server, privIp, pubIp):
+        """Bind an already allocated floating IP to `server`. Always returns `pubIp`."""
+        portId = networking.resolvePortIdForFixedIp(self.conn, server, privIp) if privIp else None
+        if not portId:
+            return pubIp
+
+        try:
+            fip = self.conn.network.find_ip(pubIp)
+            if fip:
+                self.conn.network.update_ip(fip, port_id=portId)
+        except Exception as exc:
+            logger.warning("Failed to attach FIP %s via port update, falling back: %s", pubIp, exc)
+            try:
+                self.conn.compute.add_floating_ip_to_server(server, pubIp)
+            except Exception as exc2:
+                logger.error("Failed to attach FIP %s via legacy API: %s", pubIp, exc2)
+        return pubIp
+
+    def _ensureFloatingIp(self, server, privIp, requestedPubIp=None):
+        """
+        Ensure `server` ends up with a floating IP, and return it, or None.
+
+        When `requestedPubIp` is set, that already allocated address is bound to
+        the server; otherwise the floating IP the server already carries is
+        reused, and a new one is allocated only as a last resort.
+        This never raises: callers get None when no address could be obtained.
+        """
+        if not server:
+            return None
+
+        if requestedPubIp:
+            return self._attachExistingFloatingIp(server, privIp, requestedPubIp)
+
+        _, actualPubIp = self._getServerIps(server)
+        if actualPubIp:
+            return actualPubIp
+
+        try:
+            return self._allocateFloatingIp(server, privIp)
+        except Exception as exc:
+            logger.warning(
+                "Failed to allocate a floating IP for server %s: %s",
+                getattr(server, "id", "?"), exc,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Instance creation
+    # ------------------------------------------------------------------
+
+    def _resolveServerSpec(self, numCPU, gigaRAM):
+        """
+        Resolve the flavor, image, NIC and security groups shared by a batch.
+
+        Done once up front rather than inside each worker: it turns N identical
+        lookups into a single one, and leaves the threads with nothing to do but
+        issue their own create request.
+        """
+        flavorName = self.instType.get(str(numCPU), {}).get(str(gigaRAM))
+        if not flavorName:
+            raise RuntimeError("No instance type for {} vCPU / {} GiB".format(numCPU, gigaRAM))
+
+        flavor = self.conn.compute.find_flavor(flavorName)
+        if not flavor:
+            raise RuntimeError("Flavor not found: {}".format(flavorName))
+
+        image = self.conn.compute.find_image(self.ami)
+        if not image:
+            raise RuntimeError("Image not found: {}".format(self.ami))
+
+        nics = self._buildPrimaryNic()
+        if not nics:
+            raise RuntimeError("No primary NIC could be built (check interface_1/ network/ subnet config)")
+
+        secGroups = []
+        if isinstance(self.secuGrp, dict):
+            for key in ["admin", "app"]:
+                sg = self.secuGrp.get(key)
+                if sg:
+                    secGroups.append({"name": sg})
+
+        return {
+            "image_id": image.id,
+            "flavor_id": flavor.id,
+            "networks": nics,
+            "security_groups": secGroups if secGroups else None,
+            "key_name": self.keyPair,
+            "user_data": self.userData,
+            "metadata": {"cpu_count": str(numCPU)},
+        }
+
+    def _createServerOnly(self, serverSpec, name=None):
+        """Send one create request, without waiting for ACTIVE. Runs in a worker thread."""
+        serverName = "{}.{}".format(self.instName, name) if name else self.instName
+        server = self.conn.compute.create_server(name=serverName, **serverSpec)
+        return server.id
+
+    def _deleteServerQuietly(self, serverId, reason):
+        """Delete a server, reporting but never propagating a failure."""
+        try:
+            self.conn.compute.delete_server(serverId, ignore_missing=True)
+            logger.info("Server %s deleted %s", serverId, reason)
+        except Exception as exc:
+            logger.error("Failed to delete server %s %s: %s", serverId, reason, exc)
+
+    def _submitServerCreations(self, serverNames, serverSpec):
+        """
+        Fire every create request in parallel, without waiting for the servers.
+        Returns a (createdIds, failures, firstError) triple.
+        """
+        maxWorkers = min(max(1, len(serverNames)), _MAX_PARALLEL_WORKERS)
+        createdIds = []
+        failures = 0
+        firstError = None
+
+        with ThreadPoolExecutor(max_workers=maxWorkers) as executor:
+            futures = [
+                executor.submit(self._createServerOnly, serverSpec, serverName)
+                for serverName in serverNames
+            ]
+            for fut in as_completed(futures):
+                try:
+                    createdIds.append(fut.result())
+                except Exception as err:
+                    failures += 1
+                    if firstError is None:
+                        firstError = err
+                    logger.error("Create request failed: %s", err)
+
+        return createdIds, failures, firstError
+
+    def _pollServers(self, serverIds):
+        """Fetch the current state of `serverIds` with a single list call."""
+        try:
+            return {
+                server.id: server
+                for server in self.conn.compute.servers(details=True)
+                if server.id in serverIds
+            }
+        except Exception as exc:
+            logger.warning("Cannot poll server states, will retry: %s", exc)
+            return {}
+
+    def _awaitServers(self, createdIds, numCPU, gigaRAM, timeout, requestedIp=None):
+        """
+        Wait for the servers to reach ACTIVE and give each one a floating IP.
+        Servers that end up in ERROR or exceed `timeout` are deleted.
+        Returns a (results, failures) pair.
+        """
+        results = []
+        failures = 0
+        pending = set(createdIds)
+        startTime = time.time()
+
+        while pending and (time.time() - startTime) < timeout:
+            for serverId, server in self._pollServers(pending).items():
+                status = (getattr(server, "status", "") or "").upper()
+
+                if status == "ACTIVE":
+                    pending.discard(serverId)
+                    privIp, actualPubIp = self._getServerIps(server)
+                    pubIp = requestedIp or actualPubIp
+                    if not pubIp or (requestedIp and requestedIp != actualPubIp):
+                        pubIp = self._ensureFloatingIp(server, privIp, requestedIp)
+                    logger.info(
+                        "Created Instance: %s, %s, %s, %sVCPUs, %sG",
+                        serverId, privIp, pubIp, numCPU, gigaRAM,
+                    )
+                    results.append({"id": serverId, "ip": pubIp})
+
+                elif status == "ERROR":
+                    pending.discard(serverId)
+                    failures += 1
+                    logger.error("Server %s in ERROR state", serverId)
+                    self._deleteServerQuietly(serverId, "after ERROR state")
+
+            if pending:
+                time.sleep(_POLL_INTERVAL)
+
+        for serverId in pending:
+            failures += 1
+            logger.warning("Server %s creation timed out after %ss", serverId, timeout)
+            self._deleteServerQuietly(serverId, "after creation timeout")
+
+        return results, failures
+
+    def _createInstances(self, serverNames, numCPU, gigaRAM, timeoutSeconds=None,
+                         requestedIp=None, wait=True):
+        """
+        Create one server per entry in `serverNames`.
+
+        With `wait`, the servers are polled until they are usable and `results`
+        holds one {id, ip} dict per server that reached ACTIVE. Without it, the
+        call returns as soon as the requests are accepted and the addresses are
+        not known yet; reconcile() finishes the job on a later iteration.
+
+        Returns a (results, firstError) pair.
+        """
+        if not self.conn:
+            raise RuntimeError("Provider not configured")
+        if not serverNames:
+            return [], None
+
+        timeout = int(
+            timeoutSeconds if timeoutSeconds is not None else _DEFAULT_CREATE_TIMEOUT
+        )
+        try:
+            serverSpec = self._resolveServerSpec(numCPU, gigaRAM)
+        except Exception as err:
+            # Reported like a create failure so the batch path keeps returning an
+            # empty list while createInstance() can still re-raise the cause.
+            logger.error("Cannot resolve the server specification: %s", err)
+            return [], err
+
+        createdIds, failures, firstError = self._submitServerCreations(
+            serverNames, serverSpec
+        )
+
+        if not wait:
+            logger.info(
+                "OpenStack batch create submitted: requested=%s, started=%s, failed=%s",
+                len(serverNames), len(createdIds), failures,
+            )
+            return [{"id": serverId, "ip": None} for serverId in createdIds], firstError
+
+        results = []
+        if createdIds:
+            results, waitFailures = self._awaitServers(
+                createdIds, numCPU, gigaRAM, timeout, requestedIp
+            )
+            failures += waitFailures
+
+        logger.info(
+            "OpenStack batch create done: requested=%s, started=%s, active=%s, failed=%s",
+            len(serverNames), len(createdIds), len(results), failures,
+        )
+        return results, firstError
+
+    def createInstance(self, numCPU, gigaRAM, name=None, ip=None):
+        results, firstError = self._createInstances(
+            [name], numCPU, gigaRAM, requestedIp=ip
+        )
+        if results:
+            return results[0]
+        if firstError is not None:
+            raise firstError
+        raise RuntimeError(
+            "Instance {} never reached ACTIVE state".format(name or self.instName)
+        )
+
+    def createInstancesParallel(self, count, numCPU, gigaRAM, name=None, timeoutSeconds=None):
+        """
+        Fire the creations and return without waiting for the servers to boot.
+
+        Waiting here used to freeze every scaling decision for as long as the
+        slowest instance took to appear, so a single stuck creation blinded the
+        scaler for minutes. What the requests leave behind, floating IPs to
+        attach and servers that will never boot, is settled by reconcile().
+        """
+        serverNames = [
+            "{}-{}".format(name, i) if name else None
+            for i in range(max(0, int(count)))
+        ]
+        results, _ = self._createInstances(serverNames, numCPU, gigaRAM, wait=False)
+        return results
+
+    # ------------------------------------------------------------------
+    # Reconciliation
+    # ------------------------------------------------------------------
+
+    def reconcile(self, timeoutSeconds=None):
+        """
+        Finish what fire-and-forget creation left pending.
+
+        Servers that have become ACTIVE are given the floating IP that the
+        creation path no longer waits around to attach, and those that will never
+        make it, in ERROR or still building past the timeout, are removed so they
+        stop holding quota.
+        """
+        if not self.conn:
+            return
+
+        timeout = int(
+            timeoutSeconds if timeoutSeconds is not None else _DEFAULT_CREATE_TIMEOUT
+        )
+        try:
+            servers = list(self.conn.compute.servers(details=True))
+        except Exception as exc:
+            logger.warning("Cannot list servers for reconciliation: %s", exc)
+            return
+
+        attached = 0
+        removed = 0
+
+        for server in servers:
+            if not self._isManagedServer(server):
+                continue
+            status = (getattr(server, "status", "") or "").upper()
+
+            if status == "ERROR":
+                self._deleteServerQuietly(server.id, "after ERROR state")
+                removed += 1
+                continue
+
+            if status == "BUILD":
+                age = self._serverAgeSeconds(server)
+                if age is not None and age > timeout:
+                    logger.warning(
+                        "Server %s still building after %ss, removing it",
+                        server.id, int(age),
+                    )
+                    self._deleteServerQuietly(server.id, "after creation timeout")
+                    removed += 1
+                continue
+
+            if status != "ACTIVE":
+                continue
+
+            privIp, pubIp = self._getServerIps(server)
+            if pubIp or not privIp:
+                continue
+
+            try:
+                newIp = self._ensureFloatingIp(server, privIp)
+            except Exception as exc:
+                logger.error("Cannot give server %s a floating IP: %s", server.id, exc)
+                continue
+            if newIp:
+                logger.info("Attached floating IP %s to server %s", newIp, server.id)
+                attached += 1
+
+        if attached or removed:
+            logger.info(
+                "Reconciliation done: floating_ips_attached=%s, servers_removed=%s",
+                attached, removed,
+            )
+
+    # ------------------------------------------------------------------
+    # Instance destruction
+    # ------------------------------------------------------------------
+
+    def _releaseFloatingIp(self, pubIp):
+        """Return a floating IP to the pool, best-effort."""
+        try:
+            fip = self.conn.network.find_ip(pubIp)
+            if fip:
+                self.conn.network.delete_ip(fip)
+        except Exception as exc:
+            logger.warning("Failed to release floating IP %s: %s", pubIp, exc)
+
+    def destroyInstances(self, ipList):
+        if not self.conn:
+            return
+
+        serversByIp = self._buildServersByIpIndex()
+        pendingVolumeIds = []
+        logger.info(
+            "Destroy requested for %s IP(s); managed servers indexed=%s; volume deletion=%s",
+            len(ipList or []),
+            len(serversByIp),
+            "ENABLED" if self.deleteVolumesOnDestroy else "DISABLED",
+        )
+
+        for ip in ipList:
+            if not ip:
+                logger.warning("destroyInstances called with None/empty IP, skipping")
+                continue
+
+            server = serversByIp.get(ip)
+            if not server:
+                logger.warning("No server found for IP %s, skipping", ip)
+                continue
+
+            instanceId = server.id
+            privIp, pubIp = self._getServerIps(server)
+
+            try:
+                isPrivate = ip_address(ip).is_private
+            except (ValueError, TypeError):
+                isPrivate = False
+
+            if isPrivate:
+                privIp = ip
+            else:
+                pubIp = ip
+
+            if self.deleteVolumesOnDestroy:
+                volumeIds = volumes.getServerVolumeIds(self.conn, server)
+                pendingVolumeIds.extend(volumeIds)
+                logger.info(
+                    "Collected %s volume(s) for server %s before deletion: %s",
+                    len(volumeIds), instanceId, volumeIds,
+                )
+
+            if pubIp:
+                try:
+                    self.conn.compute.remove_floating_ip_from_server(server, pubIp)
+                except Exception as exc:
+                    logger.debug("Failed to disassociate FIP %s from server %s: %s", pubIp, instanceId, exc)
+
+            try:
+                self.conn.compute.delete_server(server, ignore_missing=True)
+            except Exception as exc:
+                logger.error("Failed to delete server %s: %s", instanceId, exc)
+
+            if pubIp:
+                self._releaseFloatingIp(pubIp)
+
+            logger.info("Deleted Instance: %s, %s, %s", instanceId, privIp, pubIp)
+
+        if not self.deleteVolumesOnDestroy:
+            logger.info("Volume deletion skipped because delete_volumes_on_destroy is disabled")
+        elif pendingVolumeIds:
+            volumes.deleteVolumes(self.conn, pendingVolumeIds)
+        else:
+            logger.info("Volume deletion enabled but no attached volumes were collected")

--- a/deploy/scaler/src/providers/openstackProvider/volumes.py
+++ b/deploy/scaler/src/providers/openstackProvider/volumes.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+"""Cinder volume handling for the OpenStack provider."""
+
+import logging
+import time
+
+from .errors import isNotFoundError
+
+logger = logging.getLogger(__name__)
+
+# A volume stays "in-use" for a while after its server is deleted, so deletion
+# is retried rather than attempted once.
+_MAX_DELETE_ATTEMPTS = 6
+_DELETE_RETRY_DELAY = 10
+
+
+def getServerVolumeIds(conn, server):
+    """Return the ids of the volumes attached to `server`."""
+    serverId = getattr(server, "id", "?")
+    volumeIds = []
+
+    try:
+        for vol in getattr(server, "attached_volumes", None) or []:
+            volId = vol.get("id") if isinstance(vol, dict) else getattr(vol, "id", None)
+            if volId:
+                volumeIds.append(volId)
+    except Exception as exc:
+        logger.warning("Cannot list attached volumes for server %s: %s", serverId, exc)
+
+    # The server detail response does not always carry the attachments, so fall
+    # back to the dedicated Nova call.
+    if not volumeIds:
+        try:
+            for attachment in conn.compute.volume_attachments(server):
+                volId = getattr(attachment, "volume_id", None)
+                if volId:
+                    volumeIds.append(volId)
+        except Exception as exc:
+            logger.warning("Cannot list volume attachments for server %s: %s", serverId, exc)
+
+    logger.debug("Server %s has volumes: %s", serverId, volumeIds)
+    return volumeIds
+
+
+def _tryDeleteVolume(conn, volId, attempt):
+    """
+    Attempt one deletion of `volId`.
+    Returns "deleted", "absent", "pending" or "failed".
+    """
+    try:
+        vol = conn.block_storage.find_volume(volId, ignore_missing=True)
+        if not vol:
+            return "absent"
+
+        status = (getattr(vol, "status", "") or "").lower()
+        if status == "in-use":
+            logger.info(
+                "Volume %s still in-use on attempt %s/%s, will retry",
+                volId, attempt + 1, _MAX_DELETE_ATTEMPTS,
+            )
+            return "pending"
+
+        conn.block_storage.delete_volume(volId, ignore_missing=True)
+        logger.info("Delete request sent for volume %s (status=%s)", volId, status or "unknown")
+        return "deleted"
+
+    except Exception as exc:
+        if isNotFoundError(exc):
+            return "absent"
+        if attempt < (_MAX_DELETE_ATTEMPTS - 1):
+            logger.warning(
+                "Volume %s delete failed on attempt %s/%s, retrying: %s",
+                volId, attempt + 1, _MAX_DELETE_ATTEMPTS, exc,
+            )
+            return "pending"
+        logger.error(
+            "Volume %s delete failed after %s attempts: %s",
+            volId, _MAX_DELETE_ATTEMPTS, exc,
+        )
+        return "failed"
+
+
+def deleteVolumes(conn, volumeIds):
+    """Delete every volume in `volumeIds`, retrying while they remain in-use."""
+    remaining = list(dict.fromkeys(volumeIds))
+    if not remaining:
+        logger.info("No attached volumes queued for deletion")
+        return
+
+    requested = len(remaining)
+    logger.info("Starting volume deletion for %s volume(s): %s", requested, remaining)
+    deleted = []
+    alreadyGone = []
+    failed = []
+
+    for attempt in range(_MAX_DELETE_ATTEMPTS):
+        if not remaining:
+            break
+        if attempt > 0:
+            time.sleep(_DELETE_RETRY_DELAY)
+        logger.info(
+            "Volume deletion attempt %s/%s for %s pending volume(s)",
+            attempt + 1, _MAX_DELETE_ATTEMPTS, len(remaining),
+        )
+
+        stillPending = []
+        for volId in remaining:
+            outcome = _tryDeleteVolume(conn, volId, attempt)
+            if outcome == "deleted":
+                deleted.append(volId)
+            elif outcome == "absent":
+                logger.info("Volume %s already absent (treated as deleted)", volId)
+                alreadyGone.append(volId)
+            elif outcome == "pending":
+                stillPending.append(volId)
+            else:
+                failed.append(volId)
+        remaining = stillPending
+
+    failed.extend(volId for volId in remaining if volId not in failed)
+
+    logger.info(
+        "Volume deletion summary: requested=%s, deleted=%s, already_deleted=%s, failed=%s",
+        requested, len(deleted), len(alreadyGone), len(failed),
+    )
+    if failed:
+        logger.warning("Volume deletion failed for IDs: %s", failed)

--- a/deploy/scaler/src/webService.py
+++ b/deploy/scaler/src/webService.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python
 import importlib
+import logging
 import sys
 import os
-import datetime as dt
 import inspect
 import re
 import web
 import json
+from manageInstance import ManageInstance
 from ScalerSIP  import ScalerSIP
 from ScalerMedia import ScalerMedia
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+
+logger = logging.getLogger(__name__)
 
 scalerConfigFile = os.environ.get("SCALER_CONFIG_FILE", "scaler.json")
 cspName =  os.environ.get("CSP_NAME", "outscale")
@@ -16,6 +25,64 @@ cspConfigFile = os.environ.get("CSP_CONFIG_FILE", "sipmediagw_sample.json")
 cspProfile = os.environ.get("CSP_PROFILE", "visio-dev")
 
 scalerType = os.environ.get("SCALER_TYPE", "SIP")
+
+
+def _importCspModule():
+    """Import the provider module named by CSP_NAME."""
+    providersDir = "{}/providers".format(os.path.dirname(os.path.abspath(__file__)))
+    if providersDir not in sys.path:
+        sys.path.append(providersDir)
+
+    # Legacy providers are plain modules sitting inside their own directory, and
+    # some of them import siblings by bare name, so that directory must be on the
+    # path too. Packages such as openstackProvider are found via providersDir.
+    legacyDir = "{}/{}".format(providersDir, cspName)
+    if os.path.isdir(legacyDir) and legacyDir not in sys.path:
+        sys.path.append(legacyDir)
+
+    return importlib.import_module(cspName)
+
+
+def _findCspClass(mod):
+    """Return the single ManageInstance subclass exported by a provider module."""
+    candidates = [
+        cls
+        for _, cls in inspect.getmembers(mod, inspect.isclass)
+        if issubclass(cls, ManageInstance) and cls is not ManageInstance
+    ]
+    if not candidates:
+        raise RuntimeError(
+            "Provider '{}' exports no ManageInstance subclass".format(cspName)
+        )
+    if len(candidates) > 1:
+        raise RuntimeError(
+            "Provider '{}' exports several ManageInstance subclasses: {}".format(
+                cspName, [cls.__name__ for cls in candidates]
+            )
+        )
+    return candidates[0]
+
+
+def _buildScaler():
+    # Build the CSP provider + Scaler once for the process lifetime. Rebuilding
+    # them on every HTTP request leaks provider connections (OpenStack especially).
+    mod = _importCspModule()
+    cspObj = _findCspClass(mod)
+    logger.info("Loaded CSP provider %s from '%s'", cspObj.__name__, cspName)
+
+    csp = cspObj(cspProfile)
+
+    if scalerType.upper() == "SIP":
+        scaler = ScalerSIP(csp)
+    else:
+        scaler = ScalerMedia(csp)
+
+    scaler.configure("config/{}".format(scalerConfigFile))
+    return scaler
+
+
+_scaler = _buildScaler()
+
 
 def authorize(func):
     def inner(*args, **kwargs):
@@ -41,34 +108,19 @@ def authorize(func):
 
 class Scaling:
     def __init__(self) -> None:
-        # Get a manageInstance object from CSP file name
-        sys.path.append("{}/providers/{}".format(os.path.dirname(os.path.abspath(__file__)), cspName))
-        modName = cspName
-        print("CSP mod name: "+modName, flush=True)
-        mod = importlib.import_module(modName)
-        isClassMember = lambda member: inspect.isclass(member) and member.__module__ == modName
-        cspObj = inspect.getmembers(mod, isClassMember)[0][1]
-
-        csp = cspObj(cspProfile)
-        #initData = {}
-        #csp.configureInstance("{}/config/{}".format(cspName, cspConfigFile), initData)
-        
-        if scalerType.upper() == "SIP":
-            self.scaler = ScalerSIP(csp)
-        else:
-            self.scaler = ScalerMedia(csp)
-
-        self.scaler.configure("config/{}".format(scalerConfigFile))
+        self.scaler = _scaler
 
     @authorize
     def GET(self, args=None):
         data = web.input()
         initData = { scalerType.lower() : {'main_app' : self.scaler.config['main_app'],
-                                           'assets_url' : self.scaler.config['assets_url']}}
+                                           'assets_url' : self.scaler.config['assets_url']},
+                     'gw_name_prefix': self.scaler.config.get('gw_name_prefix')}
         self.scaler.csp.configureInstance("{}/providers/{}/config/{}".format(
             os.path.dirname(os.path.abspath(__file__)), cspName, cspConfigFile), initData)
         if 'auto' in data.keys():
             try:
+                self.scaler.reconcile()
                 self.scaler.cleanup()
                 if self.scaler.scale() == 0:
                     web.ctx.status = '200 OK'
@@ -77,7 +129,9 @@ class Scaling:
                 return "The scaler iteration failed: {}".format(error)
         if 'up' in data.keys():
             try:
-                instRes = self.scaler.csp.createInstance('4','4', name='mediagw')
+                instRes = self.scaler.csp.createInstance(
+                    '4','4', name=self.scaler.config.get('gw_name_prefix') or 'mediagw'
+                )
                 web.ctx.status = '200 OK'
                 return json.dumps({"status": "success", "instance": instRes})
             except Exception as error:


### PR DESCRIPTION
## Summary
- Add `openstackProvider` as an optional CSP (`CSP_NAME=openstackProvider`). Default remains Outscale.
- Turn `ManageInstance` into an ABC and load the provider by subclass, so packages (OpenStack) and legacy modules (Outscale) share one loader.
- Commit only `sipmediagw.json.example`; real credentials are gitignored.
- `scale()` is unchanged: OpenStack `createInstance` still waits; `createInstancesParallel` / `reconcile` are available for a later PR.
