### PR TITLE
[Added] expose Visio side panel state and an info panel key

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -501,6 +501,13 @@ class DockerGateway:
                 "window.meeting.mediaState() : null;"
             )
             return {"ack": True, "mediaState": mediaState}
+        elif payload['command'] == 'panelState':
+            panelState = self.executeInExistingChromeSession(
+                gwId,
+                "return (window.meeting && window.meeting.panelState) ? "
+                "window.meeting.panelState() : null;"
+            )
+            return {"ack": True, "panelState": panelState}
         elif payload['command'] == 'microphone':
             microphoneState = payload.get('param1')
             if microphoneState not in ('on', 'off'):

--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -152,6 +152,26 @@ class Visio extends UIHelper{
         }
         return true;
     }
+    panelState() {
+        // Visio's side panels (chat, participants, info) carry a data-attr
+        // suffixed -closed or -open, and are mutually exclusive: opening one
+        // closes the one that was open. The raise-hand button follows another
+        // convention, its label naming the available action, so -hand-lower
+        // means the hand is currently raised.
+        //
+        // The meeting tools panel (toggle-tools) is left out: its data-attr is
+        // the same whether it is open or closed, so its state cannot be
+        // observed this way.
+        const open = (name) =>
+            document.querySelector('[data-attr="controls-' + name + '-open"]') !== null;
+        return {
+            chat: open('chat'),
+            participants: open('participants'),
+            info: open('info'),
+            handRaised:
+                document.querySelector('[data-attr="controls-hand-lower"]') !== null
+        };
+    }
     interact(key) {
         const reactionKeys = {
             "6": "thumbs-up",
@@ -171,6 +191,8 @@ class Visio extends UIHelper{
             document.querySelector('button[data-attr*="controls-hand-raise"], button[data-attr*="controls-hand-lower"]').click();
         if (key == "5")
             document.querySelector('button[data-attr*="controls-participants-closed"], button[data-attr*="controls-participants-open"]').click();
+        if (key == "0")
+            document.querySelector('button[data-attr*="controls-info-closed"], button[data-attr*="controls-info-open"]').click();
         if (key == "s" || key == "q") {
             document.querySelector('[data-attr*="controls-screenshare"]').click();
 


### PR DESCRIPTION
The side panel toggles on a room endpoint were blind: they flipped their own value and assumed the conference followed. Visio closes the panel that was open when another one opens, and sendChat opens the chat panel on its own, so a toggle would soon show the opposite of the truth.

visio.js gains panelState(), reporting whether the chat, participants and info panels are open, plus whether the hand is raised. Key 0 toggles the info panel, which had no key at all: it carries the meeting URL, phone number and PIN, which a room may need to pass on.

HTTPLauncher.py gains the matching panelState command, returning null on connectors that do not implement it.

The meeting tools panel is left out: its data-attr is the same whether it is open or closed, so its state cannot be observed this way. The comment in panelState() says so, to save the next reader the measurements.

Tested against a Visio conference: keys 3, 5 and 0 each open their panel and close the previous one, key 4 raises the hand without affecting any panel.