### PR TITLE
[Added] uiState, a single read of the Visio UI state

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -501,6 +501,13 @@ class DockerGateway:
                 "window.meeting.mediaState() : null;"
             )
             return {"ack": True, "mediaState": mediaState}
+        elif payload['command'] == 'uiState':
+            uiState = self.executeInExistingChromeSession(
+                gwId,
+                "return (window.meeting && window.meeting.uiState) ? "
+                "window.meeting.uiState() : null;"
+            )
+            return {"ack": True, "uiState": uiState}
         elif payload['command'] == 'panelState':
             panelState = self.executeInExistingChromeSession(
                 gwId,

--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -161,10 +161,6 @@ class Visio extends UIHelper{
         return true;
     }
     uiState() {
-        // Single read for clients that need the whole picture at once: a room
-        // endpoint refreshing its buttons, or the companion page. Each call
-        // costs a round trip to the gateway, so asking for media and panel
-        // state separately doubles it for no reason.
         return {
             media: this.mediaState(),
             panels: this.panelState()

--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -160,6 +160,16 @@ class Visio extends UIHelper{
         }
         return true;
     }
+    uiState() {
+        // Single read for clients that need the whole picture at once: a room
+        // endpoint refreshing its buttons, or the companion page. Each call
+        // costs a round trip to the gateway, so asking for media and panel
+        // state separately doubles it for no reason.
+        return {
+            media: this.mediaState(),
+            panels: this.panelState()
+        };
+    }
     panelState() {
         // Visio's side panels (chat, participants, info) carry a data-attr
         // suffixed -closed or -open, and are mutually exclusive: opening one


### PR DESCRIPTION
Clients that refresh their whole interface — a room endpoint reopening its control panel, the companion page — need the media state and the panel state together. Asking for both means two round trips to the gateway, each spawning a browser session, for one user action.

uiState composes mediaState() and panelState() and returns them in one response. Both remain available on their own: a client that only needs the microphone state should keep calling mediaState.

Returns null on connectors that implement neither.