### PR TITLE
[Added] camera on|off command for Visio

### DIFF
--- a/HTTPLauncher.py
+++ b/HTTPLauncher.py
@@ -508,6 +508,16 @@ class DockerGateway:
                 "window.meeting.panelState() : null;"
             )
             return {"ack": True, "panelState": panelState}
+        elif payload['command'] == 'camera':
+            cameraState = payload.get('param1')
+            if cameraState not in ('on', 'off'):
+                raise ValueError("camera param1 must be 'on' or 'off'")
+            self.executeInExistingChromeSession(
+                gwId,
+                "return window.meeting.camera(arguments[0]);",
+                cameraState
+            )
+            return {"ack": True, "camera": cameraState}
         elif payload['command'] == 'microphone':
             microphoneState = payload.get('param1')
             if microphoneState not in ('on', 'off'):

--- a/browsing/assets/visio.js
+++ b/browsing/assets/visio.js
@@ -130,6 +130,24 @@ class Visio extends UIHelper{
             microphoneButton.click();
         }
     }
+    camera(param) {
+        const state = this.mediaState();
+        if (!state) {
+            return;
+        }
+
+        const shouldToggle = (param === 'on' && !state.camera) ||
+                             (param === 'off' && state.camera);
+
+        if (shouldToggle) {
+            const cameraButton = document.querySelector('[aria-label*="Ctrl+e"]');
+            if (!cameraButton) {
+                console.error('[\u2717] Camera button not found');
+                return;
+            }
+            cameraButton.click();
+        }
+    }
     async reaction(name) {
         const known = ['thumbs-up', 'thumbs-down', 'clapping-hands', 'red-heart',
                        'face-with-tears-of-joy', 'face-with-open-mouth',


### PR DESCRIPTION
mediaState has reported the camera state since it was introduced, but nothing could act on it: a client could tell whether the camera was on, not turn it off. The microphone had its idempotent command from the start; this is its counterpart.

visio.js gains camera(param), mirroring microphone(param): it reads the current state from #media-state and only clicks when a change is needed, so sending the same value twice is a no-op.

HTTPLauncher.py gains the matching camera command, rejecting anything other than on or off.

Tested against a Visio conference in both directions, including sending the same value twice.