### PR TITLE
Fix /admin/statuses: normalize 'None' literals like /status does

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -315,13 +315,13 @@ async def adminStatus(request: Request):
             "gateway": gwIp,
             "type": cleanPart(gwType),
             "status": state,
-            "room": room if room else None,
+            "room": cleanPart(room),
             "media_duration": media_duration,
             "transcript_progress": transcript,
-            "browsing": browsing if browsing else None,
-            "peer_uri": peerUri if peerUri else None,
-            "peer_name": peerName if peerName else None,
-            "call_started": callStarted if callStarted else None,
+            "browsing": cleanPart(browsing),
+            "peer_uri": cleanPart(peerUri),
+            "peer_name": cleanPart(peerName),
+            "call_started": cleanPart(callStarted),
             "pairing_code": pairingByGateway.get(gw_id)
         }
     return result


### PR DESCRIPTION
`adminStatus()` parses the Redis mapping with raw `x if x else None` ternaries, so the literal `"None"` strings stored by the mapping format leak into the JSON response for `room`, `browsing`, `peer_uri`, `peer_name` and `call_started`.

`getGatewayStatusFromRedis()` already normalizes these fields through `cleanPart()`; this PR aligns `adminStatus()` on the same convention.

**Behaviour change:** unset fields now return `null` instead of the string `"None"`. No other schema change.

### Tests
- Registered gateway, idle: the five fields return `null`, no `"None"` string left in the response.
- Gateway in call: `room`, `browsing`, `peer_uri`, `peer_name`, `call_started` pass through unchanged.
- `pytest -k adminStatus`: identical results on `main` and on this branch.

**Note:** `test_adminStatus_returns_gateways_with_admin_token` already fails on `main` (it asserts the pre-#46 response schema); this PR does not change that result. A separate PR could bring the test back in line with the current schema.