### PR TITLE
Feat/admin auth basic no default

### DIFF
--- a/deploy/proxyAPI/README.md
+++ b/deploy/proxyAPI/README.md
@@ -158,7 +158,10 @@ Normal requests:
 curl -H "Authorization: Bearer 1234" -X POST -d '{"room":"math101"}' http://localhost:9000/start
 ```
 
-Admin requests:
+Admin requests (`PROXY_ADMIN_TOKEN` must be set, there is no default):
 ```bash
-curl -H "Authorization: Bearer admin-secret-key" http://localhost:9000/admin/statuses
+curl -H "Authorization: Bearer $PROXY_ADMIN_TOKEN" http://localhost:9000/admin/statuses
+# HTTP Basic is accepted too (any user name, the admin token as password),
+# which lets a browser open admin pages through its native prompt:
+curl -u admin:$PROXY_ADMIN_TOKEN http://localhost:9000/admin/statuses
 ```

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -20,7 +20,9 @@ redisClient = redis.Redis(host=os.getenv('REDIS_HOST', '127.0.0.1'),
                           decode_responses=True)
 
 allowedToken = os.getenv("PROXY_TOKEN", "1234")
-adminToken = os.getenv("PROXY_ADMIN_TOKEN", "admin-secret-key")
+# No default: an unset PROXY_ADMIN_TOKEN disables admin routes (same
+# convention as PROXY_ROOM_TOKEN) instead of exposing a well-known secret.
+adminToken = os.getenv("PROXY_ADMIN_TOKEN", "")
 # Dedicated token for room-side clients, which only need to resolve their own
 # gateway id. Empty by default, which keeps /gateway_id closed: the route is
 # only enabled on deployments where endpoints can be trusted to hold a secret.
@@ -102,6 +104,8 @@ def authorize(request: Request):
 
 def authorizeAdmin(request: Request):
     """Check if request has valid admin token"""
+    if not adminToken:
+        return False
     authHeader = request.headers.get("Authorization")
     if not authHeader or not re.match(r"^Bearer ", authHeader):
         return False

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import re
+import base64
 import redis
 import os
 import httpx
@@ -107,10 +108,20 @@ def authorizeAdmin(request: Request):
     if not adminToken:
         return False
     authHeader = request.headers.get("Authorization")
-    if not authHeader or not re.match(r"^Bearer ", authHeader):
+    if not authHeader:
         return False
-    token = authHeader.split(" ", 1)[1]
-    return token == adminToken
+    if re.match(r"^Bearer ", authHeader):
+        return authHeader.split(" ", 1)[1] == adminToken
+    # HTTP Basic lets a browser reach admin pages through its native
+    # prompt: any user name, the admin token as password.
+    if re.match(r"^Basic ", authHeader):
+        try:
+            decoded = base64.b64decode(authHeader.split(" ", 1)[1]).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            return False
+        _, _, password = decoded.partition(":")
+        return password == adminToken
+    return False
 
 def authorizeRoom(request: Request):
     """
@@ -284,7 +295,7 @@ async def adminStatus(request: Request):
         return Response(
             json.dumps({"error": "authorization error"}),
             status_code=401,
-            headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+            headers={"WWW-Authenticate": 'Basic realm="SIPMediaGW admin", Bearer error="invalid_token"'},
             media_type="application/json"
         )
 

--- a/test/proxy/test_proxy.py
+++ b/test/proxy/test_proxy.py
@@ -22,7 +22,14 @@ def test_authorize_invalid_token():
 
 def test_authorize_admin_valid_token():
     request = Mock(headers={"Authorization": "Bearer admin-secret-key"})
-    assert proxy.authorizeAdmin(request) is True
+    with patch.object(proxy, 'adminToken', 'admin-secret-key'):
+        assert proxy.authorizeAdmin(request) is True
+
+
+def test_authorize_admin_refuses_when_token_unset():
+    request = Mock(headers={"Authorization": "Bearer "})
+    with patch.object(proxy, 'adminToken', ''):
+        assert proxy.authorizeAdmin(request) is False
 
 
 def test_findAvailableGateway_returns_started_gateway(redis_mock):
@@ -102,6 +109,7 @@ def test_adminStatus_returns_gateways_with_admin_token(client, redis_mock):
     redis_mock.get.return_value = "1.2.3.4|working|media|room|00:00:00|00:05:30|40%|ROOM"
 
     with patch.object(proxy, 'redisClient', redis_mock), \
+        patch.object(proxy, 'adminToken', 'admin-secret-key'), \
         patch.object(proxy, 'monitorGateways', new=AsyncMock(return_value=None)):
         response = client.get(
         "/admin/statuses",
@@ -972,6 +980,7 @@ def test_adminStatus_with_empty_gateway_mapping(client, redis_mock):
     redis_mock.get.return_value = None  # Empty mapping
 
     with patch.object(proxy, 'redisClient', redis_mock), \
+        patch.object(proxy, 'adminToken', 'admin-secret-key'), \
         patch.object(proxy, 'monitorGateways', new=AsyncMock(return_value=None)):
         response = client.get(
             "/admin/statuses",

--- a/test/proxy/test_proxy.py
+++ b/test/proxy/test_proxy.py
@@ -26,6 +26,28 @@ def test_authorize_admin_valid_token():
         assert proxy.authorizeAdmin(request) is True
 
 
+def test_authorize_admin_valid_basic_password():
+    import base64
+    creds = base64.b64encode(b"admin:admin-secret-key").decode()
+    request = Mock(headers={"Authorization": f"Basic {creds}"})
+    with patch.object(proxy, 'adminToken', 'admin-secret-key'):
+        assert proxy.authorizeAdmin(request) is True
+
+
+def test_authorize_admin_invalid_basic_password():
+    import base64
+    creds = base64.b64encode(b"admin:wrong").decode()
+    request = Mock(headers={"Authorization": f"Basic {creds}"})
+    with patch.object(proxy, 'adminToken', 'admin-secret-key'):
+        assert proxy.authorizeAdmin(request) is False
+
+
+def test_authorize_admin_malformed_basic():
+    request = Mock(headers={"Authorization": "Basic %%%not-base64%%%"})
+    with patch.object(proxy, 'adminToken', 'admin-secret-key'):
+        assert proxy.authorizeAdmin(request) is False
+
+
 def test_authorize_admin_refuses_when_token_unset():
     request = Mock(headers={"Authorization": "Bearer "})
     with patch.object(proxy, 'adminToken', ''):
@@ -103,6 +125,7 @@ def test_adminStatus_requires_admin_token(client, redis_mock):
 
     assert response.status_code == 401
     assert response.json()["error"] == "authorization error"
+    assert "Basic realm=" in response.headers["WWW-Authenticate"]
 
 def test_adminStatus_returns_gateways_with_admin_token(client, redis_mock):
     redis_mock.scan_iter.return_value = ["gateway:gw1"]


### PR DESCRIPTION
## Admin routes: no default token, HTTP Basic accepted

Two changes to `authorizeAdmin()`, one commit each.

### 1. No default admin token (breaking)
`PROXY_ADMIN_TOKEN` defaulted to `"admin-secret-key"`, a value published in this repository: any deployment that forgot to set the variable exposed `/admin/*` with a well-known secret. The default is removed; when the variable is unset, admin routes refuse every request — the same convention `authorizeRoom()` already applies to `PROXY_ROOM_TOKEN`.

**Deployments relying on the default must now set `PROXY_ADMIN_TOKEN` explicitly.**

### 2. HTTP Basic on admin routes
`authorizeAdmin()` accepts `Authorization: Basic` in addition to `Bearer`: any user name, the admin token as password. The 401 response advertises both schemes (`WWW-Authenticate: Basic realm="SIPMediaGW admin", Bearer error="invalid_token"`), so a browser can reach admin endpoints through its native credentials prompt without any reverse-proxy middleware. Existing Bearer clients are unaffected.

This is the prerequisite for serving an admin console page from the proxy itself (follow-up PR).

### Tests
- New unit tests: token unset → refused; Basic valid / wrong password / malformed base64; 401 carries the Basic challenge. Existing admin tests now set the token explicitly.
- Lab: Bearer → 200, Basic → 200, wrong Basic → 401 with challenge; browser prompt on `/admin/statuses`.
- README admin example updated.

**Note:** `test_adminStatus_returns_gateways_with_admin_token` already fails on `main` (pre-#46 response schema); unchanged by this PR.