### PR TITLE
[Added] reflect the remote UI state on the companion page keys

### DIFF
--- a/browsing/assets/interact.html
+++ b/browsing/assets/interact.html
@@ -255,6 +255,13 @@
     overflow-wrap: break-word;
     word-break: break-word;
   }
+  /* A key whose remote state is known and "on": open panel, raised hand,
+     active microphone or camera. Keys with no known state look as before. */
+  .menu-key.is-on {
+    background: #1f7a3a;
+    border-color: #1f7a3a;
+    color: #fff;
+  }
 
   #log {
     font-size: 11px;
@@ -815,6 +822,45 @@ async function checkGwStatus() {
   }
 }
 
+// Maps a menu key to the uiState field that tells whether it is "on". Only
+// connectors exposing uiState (Visio today) are covered: elsewhere the keys
+// keep their previous stateless look, which is the honest fallback.
+const KEY_STATE = {
+  '1': (ui) => ui.media && ui.media.microphone,
+  '2': (ui) => ui.media && ui.media.camera,
+  '3': (ui) => ui.panels && ui.panels.chat,
+  '4': (ui) => ui.panels && ui.panels.handRaised,
+  '5': (ui) => ui.panels && ui.panels.participants,
+  '0': (ui) => ui.panels && ui.panels.info,
+};
+
+async function fetchUiState() {
+  if (!gwId) return null;
+  try {
+    const payload = { gw_id: gwId, payload: { command: 'uiState', param1: '' } };
+    const res = await fetch(apiUrl('/command'), { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data?.data?.uiState || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+// Reflects the remote state on the menu keys. Called once the menu is drawn
+// and after every key press, since most keys are toggles on the far side:
+// without a read-back, a key would keep showing what it assumed rather than
+// what the conference actually did.
+async function syncMenuKeys() {
+  const ui = await fetchUiState();
+  if (!ui) return;
+  document.querySelectorAll('.menu-key[data-dtmf]').forEach((btn) => {
+    const probe = KEY_STATE[btn.dataset.dtmf];
+    if (!probe) return;
+    btn.classList.toggle('is-on', probe(ui) === true);
+  });
+}
+
 function renderMenuOptions() {
   const menuDiv = document.getElementById('menu-options');
   menuDiv.innerHTML = '';
@@ -832,8 +878,9 @@ function renderMenuOptions() {
   for (const opt of menuOptions) {
     const btn = document.createElement('button');
     btn.className = 'key menu-key';
+    btn.dataset.dtmf = String(opt.dtmf);
     btn.innerHTML = `${getIcon(opt.icon)} ${opt[currentLang] || opt['en'] || ''}`;
-    btn.onclick = () => sendKey(opt.dtmf);
+    btn.onclick = async () => { await sendKey(opt.dtmf); await syncMenuKeys(); };
     menuDiv.appendChild(btn);
 
     // if this option represents chat (icon name contains 'chat'), append visible chat row right away
@@ -852,7 +899,7 @@ function renderMenuOptions() {
         if (e.key === 'Enter') {
           e.preventDefault();
           const v = chatInput.value.trim();
-          if (v.length) { await sendChat(v); chatInput.value = ''; }
+          if (v.length) { await sendChat(v); chatInput.value = ''; await syncMenuKeys(); }
         }
       });
 
@@ -861,7 +908,7 @@ function renderMenuOptions() {
       sendBtn.textContent = currentLang === 'fr' ? 'Envoyer' : 'Send';
       sendBtn.onclick = async () => {
         const v = chatInput.value.trim();
-        if (v.length) { await sendChat(v); chatInput.value = ''; }
+        if (v.length) { await sendChat(v); chatInput.value = ''; await syncMenuKeys(); }
       };
 
       chatRow.appendChild(chatInput);
@@ -876,6 +923,9 @@ function renderMenuOptions() {
 
   // ensure slide controls are visible now that menu options are rendered
   updateSlideControlsVisibility();
+
+  // first read of the remote state, once the keys exist
+  syncMenuKeys();
 }
 
 function getIcon(icon) {


### PR DESCRIPTION
The companion page sent its keys blindly: each one is a toggle on the far side, and nothing told the page what the conference actually did. A key showed what it had assumed, not what was true — and one press made on the room keypad was enough to make it show the opposite.

uiState is read once the menu is drawn and after every key press, and the keys whose state is known are marked accordingly: microphone, camera, chat, participants, info panel and raised hand.

Keys on connectors that do not implement uiState keep their previous stateless look. That is the honest fallback: showing no state is better than showing a guess.

Tested against a Visio conference from a phone.