### PR TITLE
[Changed] rename gateway states so each one says what it means

### DIFF
--- a/deploy/proxyAPI/README.md
+++ b/deploy/proxyAPI/README.md
@@ -74,7 +74,7 @@ Get per-gateway status/progress. Query by gw_id or room.
       "status": "success",
       "data": {
         "gw_id": "192.168.1.12",
-        "gw_state": "working",
+        "gw_state": "started",
         "room": "math101",
         "media_duration": "00:05:12",
         "transcript_progress": "45%"
@@ -91,7 +91,7 @@ Return status of all gateways. Requires admin Bearer token.
   {
     "gw01": {
       "gateway": "192.168.1.12",
-      "status": "working",
+      "status": "started",
       "room": "math101",
       "media_duration": "00:05:12",
       "transcript_progress": "45%"
@@ -110,7 +110,7 @@ Return status of all gateways. Requires admin Bearer token.
 Forward a command to a gateway.
 - Query: `?gw_id=gw01`
 - Body: forwarded as-is to gateway.
-- Note: commands are rejected (403) unless gateway state == "working".
+- Note: commands are rejected (403) unless gateway state == "started".
 - Response: proxied gateway response.
 
 ### POST /register

--- a/deploy/proxyAPI/admin.js
+++ b/deploy/proxyAPI/admin.js
@@ -68,15 +68,15 @@ const copyable = (v, cls = '') => v == null ? dash : `<span class="copy ${cls}" 
 /* The gateway field is the launcher address "host:port"; the port is fixed. */
 const hostOf = v => { const s = norm(v); return s == null ? null : s.replace(/:\d+$/, ''); };
 
-/* Derived state. "status" alone is ambiguous: "started" is a free slot
-   (container stopped, allocatable by /start) and "working" only means the
-   container runs. A SIP peer with no room yet is in the IVR; a room (with
+/* Derived state. "created" is a provisioned slot never used, "stopped" one
+   whose call has ended; both are allocatable by /start. "started" only means
+   the container runs: a SIP peer with no room yet is in the IVR, a room (with
    or without a peer, browsing-only gateways) means in conference. */
 function derive(g) {
   const peer = !!(norm(g.call_started) || norm(g.peer_uri));
   const room = !!norm(g.room);
-  if (g.status === 'started') return 'free';
-  if (g.status === 'working') return room ? 'call' : (peer ? 'ivr' : 'idle');
+  if (g.status === 'created' || g.status === 'stopped') return 'free';
+  if (g.status === 'started') return room ? 'call' : (peer ? 'ivr' : 'idle');
   return 'other';
 }
 

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -213,9 +213,6 @@ def findAvailableGateway():
         parts = value.split("|")
         gwIp = parts[redis_gw_ip_index]
         state = getPart(parts, redis_gw_state_index)
-        # A VM that has never been used and one whose call has just ended are
-        # both available. The former "started" covered the two, which this
-        # rename splits apart.
         if state in ("created", "stopped"):
             return [key, gwIp]
     return None
@@ -242,8 +239,6 @@ def updateProgressInfo(gw_id: str, parts: list, data: dict):
         parts[redis_gw_state_index] = "started"
     elif (state == "down"):
         # The container has exited; the VM stays provisioned and reusable.
-        # This is what the previous code flattened into "started", leaving a
-        # dead gateway indistinguishable from a fresh one.
         parts[redis_gw_state_index] = "stopped"
     parts[redis_gw_room_index] = f"{room}" if room else "None"
     parts[redis_gw_browsing_index] = f"{browsing}" if browsing else "None"

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -31,7 +31,13 @@ roomToken = os.getenv("PROXY_ROOM_TOKEN", "")
 
 # Redis Mapping:
 # gateway:<gw_id> => "<gw_ip>|<state>|type|room_name|start_time|<media_duration>|<transcript_progress>|<browsing>|<peer_uri>|<peer_name>|<call_started>"
-# state: started | working | stopped
+# state: created | started | stopped | deleted
+#   created  VM provisioned, container initialised once then stopped, unused
+#   started  container running, a call is in progress
+#   stopped  container stopped after a call — the VM is still reusable
+#   deleted  VM torn down
+# The two pairs answer different questions: created/deleted describe the VM,
+# started/stopped the container running on it.
 
 redis_gw_field_count = 11
 
@@ -207,7 +213,10 @@ def findAvailableGateway():
         parts = value.split("|")
         gwIp = parts[redis_gw_ip_index]
         state = getPart(parts, redis_gw_state_index)
-        if state == "started":
+        # A VM that has never been used and one whose call has just ended are
+        # both available. The former "started" covered the two, which this
+        # rename splits apart.
+        if state in ("created", "stopped"):
             return [key, gwIp]
     return None
 
@@ -230,9 +239,12 @@ def updateProgressInfo(gw_id: str, parts: list, data: dict):
         parts[redis_gw_transcript_progress_index] = f"{transcript}"
     # Update Gateway State
     if (state == "up"):
-        parts[redis_gw_state_index] = "working"
-    elif (state == "down"):
         parts[redis_gw_state_index] = "started"
+    elif (state == "down"):
+        # The container has exited; the VM stays provisioned and reusable.
+        # This is what the previous code flattened into "started", leaving a
+        # dead gateway indistinguishable from a fresh one.
+        parts[redis_gw_state_index] = "stopped"
     parts[redis_gw_room_index] = f"{room}" if room else "None"
     parts[redis_gw_browsing_index] = f"{browsing}" if browsing else "None"
     parts[redis_gw_peer_uri_index] = f"{peerUri}" if peerUri else "None"
@@ -586,7 +598,7 @@ async def startGateway(request: Request):
             rawValue = redisClient.get(f"gateway:{gw_id}")
             parts = rawValue.split("|") if rawValue else [gwIp]
             parts += [""] * (redis_gw_field_count - len(parts))
-            parts[redis_gw_state_index] = "working"
+            parts[redis_gw_state_index] = "started"
             parts[redis_gw_room_index] = room if room else None
             parts[redis_gw_browsing_index] = browsing if browsing else None
             mapping = "|".join(parts)
@@ -643,7 +655,7 @@ async def stopGateway(request: Request):
             parts[redis_gw_peer_uri_index] = ''
             parts[redis_gw_peer_name_index] = ''
             parts[redis_gw_call_started_index] = ''
-            parts[redis_gw_state_index] = "stopped"
+            parts[redis_gw_state_index] = "deleted"
             mapping = "|".join(parts)
             redisClient.set(f"gateway:{gw_id}", mapping)
             responseJson["status"] = "success"
@@ -752,11 +764,11 @@ async def genericGatewayProxy(request: Request, endpoint: str):
     parts = raw_value.split("|")
     gw_ip = parts[redis_gw_ip_index]
 
-    isWorking = (
+    isRunning = (
         len(parts) > redis_gw_state_index
-        and parts[redis_gw_state_index] == "working"
+        and parts[redis_gw_state_index] == "started"
     )
-    if not isWorking:
+    if not isRunning:
         print(f"Gateway '{gw_id}' is stopped, cannot send commands")
         raise HTTPException(status_code=403, detail=f"Gateway '{gw_id}' is stopped, cannot send commands")
 
@@ -856,7 +868,7 @@ async def registerGateway(request: Request):
             callStarted   = parts[redis_gw_call_started_index]
         else:
             # No mapping found => reset
-            gwState = "started"
+            gwState = "created"
             startTime = dt.datetime.now().isoformat()
             roomName = None
             mediaduration   = "0"

--- a/deploy/scaler/src/ScalerMedia.py
+++ b/deploy/scaler/src/ScalerMedia.py
@@ -35,7 +35,9 @@ class ScalerMedia(Scaler):
           parts = value.split("|")
           gwIp = parts[0].split(':', 1)[0]
           state = parts[1] if len(parts) > 1 else None
-          if state in ["started", "stopped"]:
+          # created: never used; stopped: call over. Both are idle, so both
+          # can be reclaimed.
+          if state in ["created", "stopped"]:
                 # No rooms assigned, can downscale
                 ipList.append(gwIp)
                 # Update gateway state to stopping
@@ -86,6 +88,6 @@ class ScalerMedia(Scaler):
         for key in self.redisClient.scan_iter(match="gateway:*"):
             value = self.redisClient.get(key)
             parts = value.split("|")
-            if len(parts) > 1 and parts[1] == "started":
+            if len(parts) > 1 and parts[1] in ("created", "stopped"):
                 readyToRun += 1
         return readyToRun

--- a/test/proxy/test_proxy.py
+++ b/test/proxy/test_proxy.py
@@ -54,9 +54,9 @@ def test_authorize_admin_refuses_when_token_unset():
         assert proxy.authorizeAdmin(request) is False
 
 
-def test_findAvailableGateway_returns_started_gateway(redis_mock):
+def test_findAvailableGateway_returns_free_gateway(redis_mock):
     redis_mock.scan_iter.return_value = ["gateway:gw1"]
-    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|created|media|room|start|0|0|None"
 
     with patch.object(proxy, 'redisClient', redis_mock):
         result = proxy.findAvailableGateway()
@@ -64,9 +64,9 @@ def test_findAvailableGateway_returns_started_gateway(redis_mock):
     assert result == ["gateway:gw1", "1.2.3.4"]
 
 
-def test_findAvailableGateway_returns_none_when_no_started_gateway(redis_mock):
+def test_findAvailableGateway_returns_none_when_all_busy(redis_mock):
     redis_mock.scan_iter.return_value = ["gateway:gw1"]
-    redis_mock.get.return_value = "1.2.3.4|stopped|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     with patch.object(proxy, 'redisClient', redis_mock):
         result = proxy.findAvailableGateway()
@@ -75,7 +75,7 @@ def test_findAvailableGateway_returns_none_when_no_started_gateway(redis_mock):
 
 
 def test_updateProgressInfo_updates_redis_mapping(redis_mock):
-    parts = ["1.2.3.4", "started", "media", "room","00:00:00"]
+    parts = ["1.2.3.4", "created", "media", "room","00:00:00"]
     data = {
         "recording_duration": "00:05:30",
         "transcript_progress": "50%",
@@ -87,7 +87,7 @@ def test_updateProgressInfo_updates_redis_mapping(redis_mock):
     with patch.object(proxy, 'redisClient', redis_mock):
         proxy.updateProgressInfo("gw1", parts, data)
 
-    expected = "1.2.3.4|working|media|room1|00:00:00|00:05:30|50%|JITSI"
+    expected = "1.2.3.4|started|media|room1|00:00:00|00:05:30|50%|JITSI"
 
     print(redis_mock.set.call_args)
     assert redis_mock.set.call_count == 1
@@ -95,7 +95,7 @@ def test_updateProgressInfo_updates_redis_mapping(redis_mock):
 
 
 def test_getGatewayStatusFromRedis_returns_status(redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room1|00:00:00|00:05:30|60%|ROOM"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room1|00:00:00|00:05:30|60%|ROOM"
 
     with patch.object(proxy, 'redisClient', redis_mock):
         result = proxy.getGatewayStatusFromRedis("gw1")
@@ -103,7 +103,7 @@ def test_getGatewayStatusFromRedis_returns_status(redis_mock):
     print(result)
     assert result["status"] == "success"
     assert result["data"]["gw_id"] == "gw1"
-    assert result["data"]["gw_state"] == "working"
+    assert result["data"]["gw_state"] == "started"
     assert result["data"]["browsing"] == "ROOM"
 
 
@@ -129,7 +129,7 @@ def test_adminStatus_requires_admin_token(client, redis_mock):
 
 def test_adminStatus_returns_gateways_with_admin_token(client, redis_mock):
     redis_mock.scan_iter.return_value = ["gateway:gw1"]
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|00:00:00|00:05:30|40%|ROOM"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|00:00:00|00:05:30|40%|ROOM"
 
     with patch.object(proxy, 'redisClient', redis_mock), \
         patch.object(proxy, 'adminToken', 'admin-secret-key'), \
@@ -144,7 +144,7 @@ def test_adminStatus_returns_gateways_with_admin_token(client, redis_mock):
     assert response.json() == {
         "gw1": {
             "gateway": "1.2.3.4",
-            "status": "working",
+            "status": "started",
             "room": "room",
             "media_duration": "00:05:30",
             "transcript_progress": "40%",
@@ -285,7 +285,7 @@ def test_authorizeAdmin_invalid_token():
 
 # ----------------------- updateProgressInfo Edge Cases ============
 def test_updateProgressInfo_with_state_down(redis_mock):
-    parts = ["1.2.3.4", "started", "media", "room"]
+    parts = ["1.2.3.4", "created", "media", "room"]
     data = {
         "gw_state": "down",
         "browsing": "IDLE",
@@ -294,12 +294,12 @@ def test_updateProgressInfo_with_state_down(redis_mock):
     with patch.object(proxy, 'redisClient', redis_mock):
         proxy.updateProgressInfo("gw1", parts, data)
 
-    expected = "1.2.3.4|started|media|None||||IDLE"
+    expected = "1.2.3.4|stopped|media|None||||IDLE"
     assert redis_mock.set.call_args[0] == ("gateway:gw1", expected)
 
 
 def test_updateProgressInfo_with_streaming_duration(redis_mock):
-    parts = ["1.2.3.4", "started", "media", "room1","0"]
+    parts = ["1.2.3.4", "created", "media", "room1","0"]
     data = {
         "room": "room1",
         "streaming_duration": "00:10:20",
@@ -368,7 +368,7 @@ def test_interact_gateway_not_found(client, redis_mock):
 
 
 def test_interact_successful_proxy(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     mock_response = Mock()
     mock_response.content = b"<html>Test</html>"
@@ -481,7 +481,7 @@ def test_start_gateway_no_available_gateways(client, redis_mock):
 
 def test_start_gateway_successful(client, redis_mock):
     redis_mock.scan_iter.return_value = ["gateway:gw1"]
-    redis_mock.get.return_value = "1.2.3.4|started|media|None|2024-01-01T00:00:00|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|created|media|None|2024-01-01T00:00:00|0|0|None"
 
     mock_response = Mock()
     mock_response.json.return_value = {"status": "success", "gw_id": "gw1"}
@@ -577,7 +577,7 @@ def test_stop_gateway_not_found(client, redis_mock):
 
 
 def test_stop_gateway_successful(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|jitsi"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|jitsi"
 
     mock_response = Mock()
     mock_response.json.return_value = {
@@ -603,7 +603,7 @@ def test_stop_gateway_successful(client, redis_mock):
 
 
 def test_stop_gateway_error_response(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     mock_response = Mock()
     mock_response.json.return_value = {
@@ -630,8 +630,8 @@ def test_stop_gateway_error_response(client, redis_mock):
 
 def test_stop_gateway_json_parse_error(client, redis_mock):
     redis_mock.get.side_effect = [
-        "1.2.3.4|working|media|room|start|0|0|None",
-        "1.2.3.4|working|media|room|start|0|0|None"
+        "1.2.3.4|started|media|room|start|0|0|None",
+        "1.2.3.4|started|media|room|start|0|0|None"
     ]
 
     mock_response = Mock()
@@ -662,7 +662,7 @@ def test_status_gateway_missing_parameters(client):
 
 
 def test_status_gateway_by_gw_id(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|00:05:30|60%|ROOM"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|00:05:30|60%|ROOM"
 
     with patch.object(proxy, 'redisClient', redis_mock), \
         patch.object(proxy, 'monitorGateways', new=AsyncMock(return_value=None)):
@@ -674,7 +674,7 @@ def test_status_gateway_by_gw_id(client, redis_mock):
 
 def test_status_gateway_by_room(client, redis_mock):
     redis_mock.scan_iter.return_value = ["gateway:gw1"]
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|00:05:30|60%|ROOM"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|00:05:30|60%|ROOM"
 
     with patch.object(proxy, 'redisClient', redis_mock), \
         patch.object(proxy, 'monitorGateways', return_value=None):
@@ -686,7 +686,7 @@ def test_status_gateway_by_room(client, redis_mock):
 
 def test_status_gateway_room_not_found(client, redis_mock):
     redis_mock.scan_iter.return_value = ["gateway:gw1"]
-    redis_mock.get.return_value = "1.2.3.4|working|media|other_room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|other_room|start|0|0|None"
 
     with patch.object(proxy, 'redisClient', redis_mock), \
         patch.object(proxy, 'monitorGateways', new=AsyncMock(return_value=None)):
@@ -707,9 +707,9 @@ def test_status_gateway_not_found(client, redis_mock):
 
 def test_status_gateway_baresip_type_monitor(client, redis_mock):
     redis_mock.get.side_effect = [
-        "1.2.3.4|working|baresip|room|start|0|0|None",  # First call returns baresip
-        "1.2.3.4|working|baresip|room|start|00:05:30|60%|ROOM",  # After monitor
-        "1.2.3.4|working|baresip|room|start|00:10:30|80%|ROOM"  # After monitor
+        "1.2.3.4|started|baresip|room|start|0|0|None",  # First call returns baresip
+        "1.2.3.4|started|baresip|room|start|00:05:30|60%|ROOM",  # After monitor
+        "1.2.3.4|started|baresip|room|start|00:10:30|80%|ROOM"  # After monitor
     ]
 
     async def mock_monitor(*args, **kwargs):
@@ -725,7 +725,7 @@ def test_status_gateway_baresip_type_monitor(client, redis_mock):
 
 def test_status_gateway_baresip_unreachable_after_monitor(client, redis_mock):
     redis_mock.get.side_effect = [
-        "1.2.3.4|working|baresip|room|start|0|0|None",  # First call
+        "1.2.3.4|started|baresip|room|start|0|0|None",  # First call
         None  # After monitor - gateway removed
     ]
 
@@ -738,7 +738,7 @@ def test_status_gateway_baresip_unreachable_after_monitor(client, redis_mock):
 
 
 def test_progress_endpoint_same_as_status(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|00:05:30|60%|ROOM"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|00:05:30|60%|ROOM"
 
     with patch.object(proxy, 'redisClient', redis_mock), \
         patch.object(proxy, 'monitorGateways', new=AsyncMock(return_value=None)):
@@ -800,7 +800,7 @@ def test_register_gateway_new_registration(client, redis_mock):
 
 
 def test_register_gateway_existing_registration(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|2024-01-01T00:00:00|00:05:30|60%|ROOM"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|2024-01-01T00:00:00|00:05:30|60%|ROOM"
 
     with patch.object(proxy, 'redisClient', redis_mock), \
         patch.object(proxy, 'monitorGateways', new=AsyncMock(return_value=None)):
@@ -934,7 +934,7 @@ def test_command_gateway_stopped(client, redis_mock):
 
 
 def test_command_gateway_successful(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     mock_response = Mock()
     mock_response.json.return_value = {"status": "success"}
@@ -957,7 +957,7 @@ def test_command_gateway_successful(client, redis_mock):
 
 
 def test_command_gateway_binary_response(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     mock_response = AsyncMock()
     mock_response.json.side_effect = ValueError("Not JSON")
@@ -978,7 +978,7 @@ def test_command_gateway_binary_response(client, redis_mock):
 
 
 def test_ivrConfig_gateway_successful(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     mock_response = Mock()
     mock_response.json.return_value = {"config": "data"}
@@ -1000,7 +1000,7 @@ def test_ivrConfig_gateway_successful(client, redis_mock):
 
 
 def test_browsing_gateway_successful(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     mock_response = Mock()
     mock_response.json.return_value = {"browsing": "data"}
@@ -1022,7 +1022,7 @@ def test_browsing_gateway_successful(client, redis_mock):
 
 
 def test_icon_gateway_successful(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     mock_response = AsyncMock()
     mock_response.json.side_effect = ValueError("Not JSON")
@@ -1043,7 +1043,7 @@ def test_icon_gateway_successful(client, redis_mock):
 
 # ----------------------- monitorOneGateway Function ============
 def test_monitorOneGateway(redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     async def mock_fetch(*args, **kwargs):
         pass
@@ -1088,7 +1088,7 @@ def test_adminStatus_with_empty_gateway_mapping(client, redis_mock):
 
 # ----------------------- statusGatewayProxy Endpoint ============
 def test_status_proxy_endpoint(client, redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|0|0|None"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|0|0|None"
 
     mock_response = Mock()
     mock_response.json.return_value = {"status": "success"}
@@ -1111,23 +1111,23 @@ def test_status_proxy_endpoint(client, redis_mock):
 
 # ----------------------- getGatewayStatusFromRedis Edge Cases ============
 def test_getGatewayStatusFromRedis_with_full_parts(redis_mock):
-    redis_mock.get.return_value = "1.2.3.4|working|media|room|start|00:05:30|60%|ROOM"
+    redis_mock.get.return_value = "1.2.3.4|started|media|room|start|00:05:30|60%|ROOM"
 
     with patch.object(proxy, 'redisClient', redis_mock):
         result = proxy.getGatewayStatusFromRedis("gw1")
 
     assert result["data"]["gw_id"] == "gw1"
-    assert result["data"]["gw_state"] == "working"
+    assert result["data"]["gw_state"] == "started"
     assert result["data"]["room"] == "room"
     assert result["data"]["browsing"] == "ROOM"
 
 
 # ----------------------- findAvailableGateway with Multiple Gateways ============
-def test_findAvailableGateway_returns_first_started(redis_mock):
+def test_findAvailableGateway_returns_first_free(redis_mock):
     redis_mock.scan_iter.return_value = ["gateway:gw1", "gateway:gw2"]
     redis_mock.get.side_effect = [
-        "1.2.3.4|stopped|media|room|start|0|0|None",
-        "5.6.7.8|started|media|room|start|0|0|None"
+        "1.2.3.4|started|media|room|start|0|0|None",
+        "5.6.7.8|stopped|media|room|start|0|0|None"
     ]
 
     with patch.object(proxy, 'redisClient', redis_mock):

--- a/test/simulation/scaler/scalerMediaSimu.py
+++ b/test/simulation/scaler/scalerMediaSimu.py
@@ -51,8 +51,8 @@ def unlockGw(config, username):
         parts = value.split("|")
         gwIp = parts[0]
         state = parts[1] if len(parts) > 1 else None
-        if state == "working":
-            redisClient.set(username, f"{gwIp}|started|{parts[2]}|{parts[3]}|{dt.datetime.now().isoformat()}")
+        if state == "started":
+            redisClient.set(username, f"{gwIp}|stopped|{parts[2]}|{parts[3]}|{dt.datetime.now().isoformat()}")
         return True
     return False
 
@@ -67,9 +67,9 @@ def printGwStates():
         value = redisClient.get(key)
         parts = value.split("|")
         state = parts[1] if len(parts) > 1 else None
-        if state == "started":
+        if state in ("created", "stopped"):
             nbGWFree += 1
-        elif state == "working":
+        elif state == "started":
             nbGWWorking += 1
         elif state == "starting":
             nbGWStarting += 1


### PR DESCRIPTION
The three states carried more than they could hold. "started" covered both a VM provisioned and never used and a gateway whose call had just ended, so /status reported "started" for a container that had exited and no caller could tell a spare gateway from a dead one. "working" only meant the container was running, and "stopped" meant the VM was gone.

    started -> created   VM provisioned, container initialised then stopped
    working -> started   container running, a call is in progress
    stopped -> deleted   VM torn down
    (new)      stopped   container stopped after a call, VM still reusable

created/deleted describe the VM, started/stopped the container running on it. The scaler keeps the same behaviour: where it tested for "started" it now tests for created or stopped, the two halves of what that single value used to cover.

Three findAvailableGateway tests are rewritten rather than renamed: they were built on "started means free, stopped means busy", which this change reverses.

Five tests in test_proxy.py already fail on main, unrelated to this: they expect an eight-field mapping where the code now writes eleven. Left for a separate fix.