### PR TITLE
[Fixed] resolve the proxy's own assets from __file__

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -33,6 +33,11 @@ roomToken = os.getenv("PROXY_ROOM_TOKEN", "")
 # gateway:<gw_id> => "<gw_ip>|<state>|type|room_name|start_time|<media_duration>|<transcript_progress>|<browsing>|<peer_uri>|<peer_name>|<call_started>"
 # state: started | working | stopped
 
+# Assets shipped next to this file. Resolved from __file__ so they are found
+# whatever the working directory: the container runs from /app, a checkout
+# does not.
+assetDir = os.path.dirname(os.path.abspath(__file__))
+
 redis_gw_field_count = 11
 
 redis_gw_ip_index = 0
@@ -66,7 +71,7 @@ async def pairing_page(request: Request):
     works and pairing.html.handleQueryParams() can show the message / prefill.
     """
     try:
-        with open("pairing.html", "r", encoding="utf-8") as f:
+        with open(os.path.join(assetDir, "pairing.html"), "r", encoding="utf-8") as f:
             return Response(content=f.read(), media_type="text/html")
     except FileNotFoundError:
         return JSONResponse(status_code=404, content={"detail": "pairing.html not found"})
@@ -93,7 +98,7 @@ async def admin_page(request: Request):
     if not authorizeAdmin(request):
         return adminUnauthorized()
     try:
-        with open("admin.html", "r", encoding="utf-8") as f:
+        with open(os.path.join(assetDir, "admin.html"), "r", encoding="utf-8") as f:
             return Response(
                 content=f.read(),
                 media_type="text/html",
@@ -111,7 +116,7 @@ async def admin_static(request: Request, file_name: str):
     if not mediaType:
         return JSONResponse(status_code=404, content={"detail": "not found"})
     try:
-        with open(file_name, "r", encoding="utf-8") as f:
+        with open(os.path.join(assetDir, file_name), "r", encoding="utf-8") as f:
             return Response(content=f.read(), media_type=mediaType)
     except FileNotFoundError:
         return JSONResponse(status_code=404, content={"detail": f"{file_name} not found"})
@@ -480,7 +485,7 @@ async def interact(request: Request):
             else:
                 # Return pairing.html and inject a JS var so the page can display a translated error
                 try:
-                    with open("pairing.html", "r", encoding="utf-8") as f:
+                    with open(os.path.join(assetDir, "pairing.html"), "r", encoding="utf-8") as f:
                         html_form = f.read()
                 except FileNotFoundError:
                     raise HTTPException(status_code=500, detail="pairing.html not found on server")
@@ -498,7 +503,7 @@ async def interact(request: Request):
                     html_with_msg = html_form.replace("</head>", injection_script + "</head>", 1)
                 return Response(content=html_with_msg, media_type="text/html")
         else:
-            with open("pairing.html", "r", encoding="utf-8") as f:
+            with open(os.path.join(assetDir, "pairing.html"), "r", encoding="utf-8") as f:
                 html_form = f.read()
             return Response(content=html_form, media_type="text/html")
 

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -33,9 +33,6 @@ roomToken = os.getenv("PROXY_ROOM_TOKEN", "")
 # gateway:<gw_id> => "<gw_ip>|<state>|type|room_name|start_time|<media_duration>|<transcript_progress>|<browsing>|<peer_uri>|<peer_name>|<call_started>"
 # state: started | working | stopped
 
-# Assets shipped next to this file. Resolved from __file__ so they are found
-# whatever the working directory: the container runs from /app, a checkout
-# does not.
 assetDir = os.path.dirname(os.path.abspath(__file__))
 
 redis_gw_field_count = 11


### PR DESCRIPTION
pairing.html, admin.html and the console's static files were opened by bare name, so they only resolved when the process ran from deploy/proxyAPI. That holds in the container, whose working directory is /app, but not from a checkout: one test fails on main for exactly this reason, and the proxy cannot be run in place for debugging.

They are now joined to a directory derived from __file__, which is where they ship. HTTPLauncher already does the same for its own assets.

The static file name stays checked against the whitelist before the join, so serving them from an absolute directory opens no path traversal.

Tested against a running proxy: /pairing, /admin/ and /admin/static all still answer 200.