### PR TITLE
[Changed] tighten the admin console's controls

### DIFF
--- a/deploy/proxyAPI/admin.css
+++ b/deploy/proxyAPI/admin.css
@@ -10,10 +10,9 @@ header { display: flex; align-items: center; gap: 12px; padding: 12px 24px; back
 header h1 { font-size: 17px; font-weight: 650; letter-spacing: .01em; }
 header .sub { color: var(--muted); font-size: 12.5px; }
 header .spacer { flex: 1; }
-header .stamp { color: var(--muted); font-size: 12.5px; }
-header button { border: 1px solid var(--line); background: var(--card); color: var(--text); border-radius: 6px; padding: 6px 14px; cursor: pointer; font: inherit; font-size: 13px; }
-header button:hover { border-color: var(--accent); color: var(--accent); }
-header button:disabled { opacity: .5; cursor: default; }
+header button, .toolbar button { border: 1px solid var(--line); background: var(--card); color: var(--text); border-radius: 6px; padding: 6px 14px; cursor: pointer; font: inherit; font-size: 13px; }
+header button:hover, .toolbar button:hover { border-color: var(--accent); color: var(--accent); }
+header button:disabled, .toolbar button:disabled { opacity: .5; cursor: default; }
 header button.lang { font-weight: 650; min-width: 44px; padding: 6px 8px; }
 
 main { padding: 18px 24px 28px; }
@@ -30,8 +29,7 @@ main { padding: 18px 24px 28px; }
 .toolbar input[type=search] { flex: 0 1 380px; padding: 7px 10px; border: 1px solid var(--line); border-radius: 6px; font: inherit; }
 .toolbar input[type=search]:focus { outline: 2px solid var(--accent); border-color: var(--accent); }
 .toolbar .shown { color: var(--muted); font-size: 12.5px; flex: 1; }
-.toolbar label { color: var(--muted); font-size: 12.5px; cursor: pointer; user-select: none; white-space: nowrap; }
-.toolbar #countdown { font-variant-numeric: tabular-nums; }
+.toolbar #countdown { color: var(--muted); font-size: 12.5px; white-space: nowrap; font-variant-numeric: tabular-nums; }
 
 table { border-collapse: collapse; width: 100%; }
 th { text-align: left; font-size: 11px; font-weight: 650; letter-spacing: .05em; text-transform: uppercase; color: var(--muted); background: var(--head); padding: 10px 12px; border-bottom: 1px solid var(--line); white-space: nowrap; }

--- a/deploy/proxyAPI/admin.html
+++ b/deploy/proxyAPI/admin.html
@@ -14,8 +14,6 @@
     <div class="sub" id="subtitle"></div>
   </div>
   <div class="spacer"></div>
-  <span class="stamp" id="stamp"></span>
-  <button id="refresh"></button>
   <button id="lang" class="lang" title="Language"></button>
 </header>
 <main>
@@ -30,7 +28,9 @@
     <div class="toolbar">
       <input type="search" id="search" autocomplete="off">
       <span class="shown" id="shown"></span>
-      <label><input type="checkbox" id="auto" checked> <span id="lAuto"></span> <span id="countdown"></span></label>
+      <button id="refresh"></button>
+      <span id="countdown" class="muted"></span>
+
     </div>
     <table>
       <thead><tr id="head"></tr></thead>

--- a/deploy/proxyAPI/admin.js
+++ b/deploy/proxyAPI/admin.js
@@ -19,8 +19,8 @@ const norm = v => (v == null || v === '' || v === 'None') ? null : v;
 
 const I18N = {
   fr: {
-    subtitle: 'supervision temps réel des passerelles SIPMediaGW', refresh: 'Actualiser', auto: 'auto 10 s',
-    countdown: s => `(${s})`, updated: 'Mis à jour à', search: 'Rechercher par ID, terminal, réunion, code, passerelle…',
+    subtitle: 'supervision temps réel des passerelles SIPMediaGW', refresh: 'Actualiser',
+    countdown: s => `prochaine dans ${s} s`, search: 'Rechercher par ID, terminal, réunion, code, passerelle…',
     shown: (n, total) => `${n} / ${total} passerelle${total > 1 ? 's' : ''}`,
     tiles: { total: 'enregistrées', free: 'slots libres', idle: 'en attente d’appel', ivr: 'en IVR', call: 'en conférence' },
     cols: ['ID', 'Type', 'État', 'Nom affiché', 'URI SIP', 'Réunion', 'Plateforme', 'Durée', 'Code', 'Passerelle', ''],
@@ -31,8 +31,8 @@ const I18N = {
     err401: 'Session expirée — rechargez la page pour vous ré-identifier.', errLoad: 'Chargement impossible',
   },
   en: {
-    subtitle: 'live supervision of registered SIPMediaGW gateways', refresh: 'Refresh', auto: 'auto 10 s',
-    countdown: s => `(${s})`, updated: 'Updated at', search: 'Search by ID, endpoint, meeting, code, gateway…',
+    subtitle: 'live supervision of registered SIPMediaGW gateways', refresh: 'Refresh',
+    countdown: s => `next in ${s} s`, search: 'Search by ID, endpoint, meeting, code, gateway…',
     shown: (n, total) => `${n} of ${total} gateway${total > 1 ? 's' : ''}`,
     tiles: { total: 'registered', free: 'free slots', idle: 'waiting for a call', ivr: 'in IVR', call: 'in conference' },
     cols: ['ID', 'Type', 'State', 'Display name', 'SIP URI', 'Meeting', 'Platform', 'Call time', 'Code', 'Gateway', ''],
@@ -135,7 +135,6 @@ function applyLanguage() {
   $('subtitle').textContent = t.subtitle;
   $('refresh').textContent = t.refresh;
   $('lang').textContent = lang === 'fr' ? 'EN' : 'FR';
-  $('lAuto').textContent = t.auto;
   $('search').placeholder = t.search;
   for (const k of ['total', 'free', 'idle', 'ivr', 'call']) {
     $('l' + k[0].toUpperCase() + k.slice(1)).textContent = t.tiles[k];
@@ -162,8 +161,12 @@ function render() {
 
   $('rows').innerHTML = shown.map(id => {
     const g = data[id], kind = kinds[id];
-    const control = kind === 'free' ? '' :
-      `<a class="btn" href="${CONFIG.pilotUrl}${encodeURIComponent(id)}" target="_blank" rel="noopener">${esc(t.control)}</a>`;
+    // Only a gateway on a call has anything to pilot, whether it sits in the
+    // IVR or in a conference. Listing the states that do rather than those
+    // that do not keeps a new state from silently getting the button.
+    const control = (kind === 'call' || kind === 'ivr')
+      ? `<a class="btn" href="${CONFIG.pilotUrl}${encodeURIComponent(id)}" target="_blank" rel="noopener">${esc(t.control)}</a>`
+      : '';
     return `<tr>
       <td>${copyable(id, 'mono')}</td>
       <td>${typeBadge(g.type)}</td>
@@ -234,10 +237,8 @@ async function load() {
     if (!res.ok) throw new Error('HTTP ' + res.status);
     data = await res.json();
     render();
-    $('stamp').textContent = `${t.updated} ${new Date().toLocaleTimeString()}`;
   } catch (e) {
     $('rows').innerHTML = `<tr><td colspan="11" class="msg err">${esc(t.errLoad)} (${esc(e.message)})</td></tr>`;
-    $('stamp').textContent = '';
   } finally {
     $('refresh').disabled = false;
     nextRefreshAt = Date.now() + CONFIG.refreshMs;
@@ -246,26 +247,19 @@ async function load() {
 
 function tick() {
   if (data) render();                          // live call durations
-  if ($('auto').checked && nextRefreshAt) {
-    $('countdown').textContent = t.countdown(Math.max(0, Math.ceil((nextRefreshAt - Date.now()) / 1000)));
-  } else {
-    $('countdown').textContent = '';
-  }
+  $('countdown').textContent = nextRefreshAt
+    ? t.countdown(Math.max(0, Math.ceil((nextRefreshAt - Date.now()) / 1000)))
+    : '';
 }
 
 function schedule() {
   clearInterval(refreshTimer);
-  if ($('auto').checked) {
-    nextRefreshAt = Date.now() + CONFIG.refreshMs;
-    refreshTimer = setInterval(load, CONFIG.refreshMs);
-  } else {
-    nextRefreshAt = 0;
-  }
+  nextRefreshAt = Date.now() + CONFIG.refreshMs;
+  refreshTimer = setInterval(load, CONFIG.refreshMs);
   tick();
 }
 
 $('refresh').addEventListener('click', load);
-$('auto').addEventListener('change', schedule);
 $('search').addEventListener('input', render);
 $('lang').addEventListener('click', () => {
   lang = lang === 'fr' ? 'en' : 'fr';


### PR DESCRIPTION
Three things the console showed without quite meaning them.

The Control button appeared for every state but "free", including a gateway that is up with no call at all, where there is nothing to pilot. It now shows for the two states that have a call — in the IVR or in a conference — so a state added later does not silently inherit it.

The auto-refresh checkbox let the operator switch off the one thing a live supervision console does. It is gone and refreshing is unconditional. The countdown that sat beside it now reads "next in 7 s" rather than a bare number, which only worked as a delay while it followed the word "auto".

Refresh and its countdown move from the header down to the toolbar, on the right of the search field, and the "Updated at" stamp goes: it said when the last load happened, where the countdown says when the next one will.