### PR TITLE
Send an optional bearer token with the call-history push

### DIFF
--- a/.env
+++ b/.env
@@ -57,6 +57,8 @@ TURN_SRV=${TURN_SRV:-$HOST_IP}
 HEPLIFY_SRV=${HEPLIFY_SRV:-$HOST_IP}
 # HTTP URL where to push the call history
 LOG_PUSH_URL=
+# Optional bearer token sent with the push; leave empty to send none
+LOG_PUSH_TOKEN=
 
 #MEDIAENC=srtp # srtp, srtp-mand, srtp-mandf, dtls_srtp or zrtp
 BFCP_FLOORCTRL=c-only

--- a/src/logParse.py
+++ b/src/logParse.py
@@ -19,6 +19,9 @@ import requests
 ### Config ###
 
 postUrl = os.environ.get("LOG_PUSH_URL", "").strip()
+# Optional shared secret expected by the receiver. Unset keeps the previous
+# behaviour: the push carries no Authorization header.
+postToken = os.environ.get("LOG_PUSH_TOKEN", "").strip()
 
 ### Regex ###
 
@@ -446,10 +449,13 @@ def pushHistory(historyPath: str) -> None:
             return
 
         payload = buildPayloadFromLines(lines, postUrl)
+        headers = {"Accept": "text/plain"}
+        if postToken:
+            headers["Authorization"] = f"Bearer {postToken}"
         resp = requests.post(
             postUrl,
             json=payload,
-            headers={"Accept": "text/plain"},
+            headers=headers,
             timeout=10,
         )
 

--- a/src/logParse.py
+++ b/src/logParse.py
@@ -19,8 +19,8 @@ import requests
 ### Config ###
 
 postUrl = os.environ.get("LOG_PUSH_URL", "").strip()
-# Optional shared secret expected by the receiver. Unset keeps the previous
-# behaviour: the push carries no Authorization header.
+# Optional shared secret expected by the receiver.
+# If unset: the push carries no Authorization header.
 postToken = os.environ.get("LOG_PUSH_TOKEN", "").strip()
 
 ### Regex ###

--- a/test/api/test_logpush_token.py
+++ b/test/api/test_logpush_token.py
@@ -1,0 +1,26 @@
+"""Bearer header is sent when LOG_PUSH_TOKEN is set, absent otherwise."""
+import importlib, os, sys
+from unittest.mock import patch, MagicMock
+
+
+def runPush(token):
+    os.environ["LOG_PUSH_URL"] = "http://collector.example/call-history"
+    os.environ["LOG_PUSH_TOKEN"] = token
+    sys.path.insert(0, "src")
+    sys.modules.pop("logParse", None)
+    mod = importlib.import_module("logParse")
+    response = MagicMock(status_code=200, text="ok")
+    with patch.object(mod, "readHistoryStable", return_value=["line"]), \
+         patch.object(mod, "buildPayloadFromLines", return_value={"call": {}}), \
+         patch.object(mod, "truncateHistory"), \
+         patch.object(mod.requests, "post", return_value=response) as post:
+        mod.pushHistory("/tmp/history.log")
+    return post.call_args.kwargs["headers"]
+
+
+def test_header_present_with_token():
+    assert runPush("s3cret")["Authorization"] == "Bearer s3cret"
+
+
+def test_no_header_without_token():
+    assert "Authorization" not in runPush("")


### PR DESCRIPTION
LOG_PUSH_URL has no authentication: any host able to reach the receiver can inject call records. This adds an optional LOG_PUSH_TOKEN, sent as Authorization: Bearer <token> when set. Unset keeps the current behaviour, so existing deployments are unaffected.

Unit tests cover both cases (header present with a token, absent without). Validated end to end on a lab gateway pushing to a token-protected receiver.