### PR TITLE
Use a fixed video jitter buffer instead of the adaptive one

### DIFF
--- a/baresip/config_default
+++ b/baresip/config_default
@@ -73,7 +73,7 @@ rtp_video_tos		136
 rtp_bandwidth		1024-2048
 audio_jitter_buffer_type	adaptive		# off, fixed, adaptive
 audio_jitter_buffer_delay	1-100		# (min. frames)-(max. packets)
-video_jitter_buffer_type	adaptive		# off, fixed, adaptive
+video_jitter_buffer_type	fixed		# off, fixed, adaptive
 video_jitter_buffer_delay	1-100		# (min. frames)-(max. packets)
 rtp_stats		yes
 rtp_timeout		60

--- a/test/environnement/gpu/config_default
+++ b/test/environnement/gpu/config_default
@@ -73,7 +73,7 @@ rtp_video_tos		136
 rtp_bandwidth		1024-2048
 audio_jitter_buffer_type	adaptive		# off, fixed, adaptive
 audio_jitter_buffer_delay	1-100		# (min. frames)-(max. packets)
-video_jitter_buffer_type	adaptive		# off, fixed, adaptive
+video_jitter_buffer_type	fixed		# off, fixed, adaptive
 video_jitter_buffer_delay	1-100		# (min. frames)-(max. packets)
 rtp_stats		yes
 rtp_timeout		60


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Video jitter buffer: <code>fixed</code> instead of <code>adaptive</code></h2>
<p>The adaptive video jitter buffer does not honour its configured maximum. On a
lab call it grew to 18 051 frames while <code>max</code> read 100, and decoding stopped
altogether: remote participants saw the room frozen, while the endpoint itself
displayed the conference normally and end-of-call statistics stayed clean
(0.6 % loss, 0.8 ms jitter, no errors).</p>
<p>Measured with <code>/video_debug</code> on the control port, two readings 30 s apart
during a call, Cisco RoomKit over H.264 on a LAN:</p>

video_jitter_buffer_type | image | cur (frames/packets), max=100 | frames decoded
-- | -- | -- | --
adaptive | 1.8.9 | 189 → 1339 | +479 (~16 fps)
adaptive | 1.9.0 | 9167 → 18051 | 0
fixed | 1.8.9 | 1/1 → 1/4 | +632 (~31 fps)
fixed | 1.9.0 | 1/6 → 1/4 | +933 (~31 fps)


<p>With <code>fixed</code> and the same delay range, the buffer stays at 1-6 packets and
decoding runs at the nominal frame rate in both images; the difference in
severity between them disappears entirely.</p>
<p>This restores the setting the project used before the v3.15 bump
(a3584204), where <code>fixed</code> was the default; <code>adaptive</code> was adopted then on the
strength of the rework upstream had done, not on measurements. Upstream baresip
has since removed the adaptive mode altogether
(<a href="https://github.com/baresip/baresip/wiki/Configuration">configuration wiki</a>),
so this also aligns with where upstream went.</p>
<p>Note for the baresip 4.x upgrade: these settings are replaced there by
<code>video_jitter_buffer_ms</code> (delay) and <code>video_jitter_buffer_size</code> (pre-allocated
packets), and <code>*_type</code> disappears. This change therefore applies to the 3.15
line only.</p>
<p>Ruled out by measurement: CPU (<code>skipc</code> at 0.4 % of captured frames, host load
0.88 on 4 cores), memory (5.9 GB available, no OOM), packet loss (42 lost out
of 6859 received over 30 s while the decoded-frame counter stayed still), and a
regression between the two images (identical <code>libbaresip.so.17.15.0</code> and
<code>libre.so.26.14.0</code> by MD5, both built from <code>v3.15.0_patchv3</code>).</p>
<p><strong>Audio is left as is.</strong> Its buffer measured 1/1 for <code>max=100</code> on the same call,
so there is nothing to fix there and no measurement to justify changing it.
Worth revisiting if upstream removed the adaptive mode for both.</p>
<p><code>test/environnement/baresip/.baresip/config</code> also carries the setting but is not
referenced by any test, so it is left untouched.</p>
<p>Verified on a rebuilt image: <code>baresip.sh</code> copies <code>config_default</code> to
<code>.baresip/config</code> at startup, so the setting takes effect with no container-side
change. On a call the buffer stayed at 1-4 packets and decoding ran at the
nominal frame rate.</p>
<p>Tested on the lab only, on 30-second calls over a LAN. Worth a run in
preproduction before it reaches production.</p></body></html><!--EndFragment-->
</body>
</html>## Video jitter buffer: `fixed` instead of `adaptive`

The adaptive video jitter buffer does not honour its configured maximum. On a
lab call it grew to 18 051 frames while `max` read 100, and decoding stopped
altogether: remote participants saw the room frozen, while the endpoint itself
displayed the conference normally and end-of-call statistics stayed clean
(0.6 % loss, 0.8 ms jitter, no errors).

Measured with `/video_debug` on the control port, two readings 30 s apart
during a call, Cisco RoomKit over H.264 on a LAN:

| `video_jitter_buffer_type` | image | `cur` (frames/packets), `max=100` | frames decoded |
|---|---|---|---|
| `adaptive` | 1.8.9 | 189 → 1339 | +479 (~16 fps) |
| `adaptive` | 1.9.0 | 9167 → 18051 | **0** |
| `fixed` | 1.8.9 | 1/1 → 1/4 | +632 (~31 fps) |
| `fixed` | 1.9.0 | 1/6 → 1/4 | +933 (~31 fps) |

With `fixed` and the same delay range, the buffer stays at 1-6 packets and
decoding runs at the nominal frame rate in both images; the difference in
severity between them disappears entirely.

This restores the setting the project used before the v3.15 bump
(a3584204), where `fixed` was the default; `adaptive` was adopted then on the
strength of the rework upstream had done, not on measurements. Upstream baresip
has since removed the adaptive mode altogether
([[configuration wiki](https://github.com/baresip/baresip/wiki/Configuration)](https://github.com/baresip/baresip/wiki/Configuration)),
so this also aligns with where upstream went.

Note for the baresip 4.x upgrade: these settings are replaced there by
`video_jitter_buffer_ms` (delay) and `video_jitter_buffer_size` (pre-allocated
packets), and `*_type` disappears. This change therefore applies to the 3.15
line only.

Ruled out by measurement: CPU (`skipc` at 0.4 % of captured frames, host load
0.88 on 4 cores), memory (5.9 GB available, no OOM), packet loss (42 lost out
of 6859 received over 30 s while the decoded-frame counter stayed still), and a
regression between the two images (identical `libbaresip.so.17.15.0` and
`libre.so.26.14.0` by MD5, both built from `v3.15.0_patchv3`).

**Audio is left as is.** Its buffer measured 1/1 for `max=100` on the same call,
so there is nothing to fix there and no measurement to justify changing it.
Worth revisiting if upstream removed the adaptive mode for both.

`test/environnement/baresip/.baresip/config` also carries the setting but is not
referenced by any test, so it is left untouched.

Verified on a rebuilt image: `baresip.sh` copies `config_default` to
`.baresip/config` at startup, so the setting takes effect with no container-side
change. On a call the buffer stayed at 1-4 packets and decoding ran at the
nominal frame rate.

Tested on the lab only, on 30-second calls over a LAN. Worth a run in
preproduction before it reaches production.