### PR TITLE
[Added] resolve a pairing code without navigating

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -473,6 +473,39 @@ def get_asset(file_name: str):
         filename=file_name,
     )
 
+@app.post("/pairing/resolve")
+async def pairingResolve(request: Request):
+    """Turn a pairing code into a gw_id, without navigating anywhere.
+
+    The pairing page submits its form to /interact and lets the answer come
+    back as a page: a refused code then lands under /interact?pairingCode=...
+    while showing the pairing form, and carries its error in a <script> the
+    proxy injects into the markup. Asking here first lets the page stay where
+    it is and say so itself.
+
+    /interact keeps accepting pairingCode as before.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+
+    # /interact matches the code as typed; normalising here means a code keyed
+    # in lower case resolves like any other.
+    code = str(body.get("code") or "").strip().upper()
+
+    gwId = redisClient.get(f"pairing:{code}") if code else None
+    if not gwId:
+        # A malformed code and an unknown one get the same answer: the endpoint
+        # says whether a code is live, and nothing else.
+        return JSONResponse(
+            status_code=404,
+            content={"status": "error", "error": {"code": 404, "detail": "Unknown pairing code"}, "data": None},
+        )
+
+    return {"status": "success", "error": None, "data": {"gw_id": gwId}}
+
+
 @app.get("/interact")
 async def interact(request: Request):
 


### PR DESCRIPTION
The pairing page submits its form to /interact, so it sends the code as a navigation without knowing whether it is any good. A refused code then comes back as the pairing page under /interact?pairingCode=..., carrying its error in a <script> the proxy inserts into the markup, before the first <script> it can find or else before </head>.

Three things follow from that. The address bar shows a page the visitor is not on, and reloading retries the code that was just turned down. The injection depends on the page's markup, which had to be checked again when the script moved to its own file. And the error can only be shown by reloading the whole page.

POST /pairing/resolve answers the question on its own: 200 with the gw_id when the code is live, 404 otherwise. The page can then stay where it is and say what happened, or send the visitor straight to /interact?gwId=...

The code goes in the body rather than the query string, so it stays out of access logs and history — getting it out of the URL being the point. A malformed code and an unknown one get the same 404: the endpoint says whether a code is live, nothing more. Codes are written with setex and expire on their own, so the window is short.

It also normalises: /interact matches the code as typed, so a code keyed in lower case fails there and resolves here.

/interact keeps accepting pairingCode unchanged; nothing is removed yet.

Tested against a live code: exact, lower case and space-padded all resolve; unknown code and empty body both 404.