### PR TITLE
[Changed] rework the pairing page and check the code before leaving it

### DIFF
--- a/deploy/proxyAPI/pairing.css
+++ b/deploy/proxyAPI/pairing.css
@@ -1,0 +1,273 @@
+/* DSFR tokens, light and dark. The palette is the only thing the dark theme
+   changes: every rule below reads these variables. */
+:root {
+  --bf: #000091;
+  --txt: #161616;
+  --muted: #666;
+  --bg: #fff;
+  --tile: #f6f6f6;
+  --border: #ddd;
+  --warning-bg: #fdeeee;
+  --warning-txt: #b34000;
+}
+[data-theme="dark"] {
+  --bf: #8585f6;
+  --txt: #fff;
+  --muted: #a8a8a8;
+  --bg: #161616;
+  --tile: #1e1e1e;
+  --border: #353535;
+  --warning-bg: #2e1a12;
+  --warning-txt: #fc5d00;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 1.5rem 1rem 2.5rem;
+  background: var(--bg);
+  color: var(--txt);
+  font-family: Marianne, Arial, Helvetica, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+}
+
+/* Brand */
+.brand {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  padding-bottom: .9rem;
+  border-bottom: 1px solid var(--border);
+}
+.brand__logo { height: 2rem; width: auto; }
+.brand__logo[src=""] { display: none; }
+.brand__name { font-size: .95rem; font-weight: 700; line-height: 1.15; }
+.brand__tagline {
+  font-size: .6rem;
+  font-weight: 700;
+  letter-spacing: .06em;
+  line-height: 1.15;
+  color: var(--muted);
+}
+
+/* Language and theme */
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+.segmented {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+.segmented__el {
+  padding: .3rem .85rem;
+  font: inherit;
+  font-size: .85rem;
+  border: 0;
+  background: transparent;
+  color: var(--txt);
+  cursor: pointer;
+}
+.segmented__el[aria-checked="true"] {
+  background: color-mix(in srgb, var(--bf) 13%, transparent);
+  color: var(--bf);
+  font-weight: 700;
+}
+.theme-toggle {
+  width: 2.1rem;
+  height: 2.1rem;
+  border: 0;
+  border-radius: 50%;
+  background: var(--tile);
+  color: var(--txt);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+h1 {
+  font-size: 1.3rem;
+  font-weight: 700;
+  text-align: center;
+  margin: 1.4rem 0 0;
+}
+
+.subtitle {
+  font-size: .85rem;
+  color: var(--muted);
+  text-align: center;
+  margin: 1.6rem 0 .6rem;
+}
+
+/* Error */
+.banner {
+  margin-top: 1rem;
+  padding: .7rem .9rem;
+  border-radius: .5rem;
+  font-size: .8rem;
+  line-height: 1.5;
+}
+/* display beats the hidden attribute, so it has to be restored explicitly */
+[hidden] { display: none !important; }
+
+.banner--error {
+  background: var(--warning-bg);
+  color: var(--warning-txt);
+  display: flex;
+  align-items: flex-start;
+  gap: .5rem;
+}
+.banner__close {
+  margin-left: auto;
+  flex: none;
+  width: 1.4rem;
+  height: 1.4rem;
+  border: 0;
+  border-radius: .25rem;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.banner__close:hover { background: rgba(0, 0, 0, .07); }
+
+/* Code entry. The whole strip takes clicks, not just the boxes: the gaps
+   between them look like part of the field, so landing there should put the
+   caret in the first empty box rather than do nothing. */
+.code {
+  display: flex;
+  justify-content: center;
+  gap: .55rem;
+  padding: .25rem 0;
+  cursor: text;
+}
+.code input {
+  width: 3rem;
+  height: 3.5rem;
+  text-align: center;
+  font: inherit;
+  font-size: 1.35rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  border: 0;
+  border-radius: .5rem;
+  background: var(--tile);
+  color: var(--txt);
+  box-shadow: inset 0 0 0 1.5px var(--border);
+}
+.code input:focus {
+  outline: 2px solid var(--bf);
+  outline-offset: 2px;
+}
+.code input.filled { box-shadow: inset 0 0 0 1.5px var(--bf); }
+
+.submit {
+  width: 100%;
+  min-height: 3rem;
+  margin-top: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  border: 0;
+  border-radius: .375rem;
+  background: var(--bf);
+  color: #fff;
+  font: inherit;
+  font-size: .95rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+.submit:disabled { opacity: .5; cursor: default; }
+
+.spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin .8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Where to find the code */
+.callout {
+  margin-top: 1.4rem;
+  padding: .9rem;
+  border-radius: .5rem;
+  background: var(--tile);
+}
+.callout__title { font-size: .85rem; font-weight: 700; margin: 0 0 .6rem; }
+.callout__text { font-size: .75rem; line-height: 1.45; color: var(--muted); margin: .6rem 0 0; }
+.callout__note { font-size: .7rem; line-height: 1.4; color: var(--muted); margin: .35rem 0 0; }
+
+/* Illustration: geometric on purpose, so it never reads as a real code */
+.sample {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+  margin: 0;
+  padding: .6rem .7rem;
+  border-radius: .5rem;
+  background: var(--bg);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+/* The illustration is not content to copy: selecting the example code would
+   only lead to typing it in. Everything else on the page stays selectable —
+   an error message is worth being able to copy. */
+.sample { user-select: none; }
+
+.sample__badge {
+  position: absolute;
+  top: -.55rem;
+  left: .6rem;
+  padding: 0 .4rem;
+  border-radius: .25rem;
+  background: var(--muted);
+  color: var(--bg);
+  font-size: .55rem;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+.sample__qr { width: 3.1rem; height: 3.1rem; flex: none; }
+.sample__qr .qr-eye { fill: var(--muted); }
+.sample__qr .qr-eye-in { fill: var(--bg); }
+.sample__qr .qr-dot { fill: var(--muted); }
+.sample__url { font-size: .62rem; color: var(--muted); }
+.sample__text { display: flex; flex-direction: column; gap: .1rem; }
+.sample__from {
+  font-size: .58rem;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.sample__code {
+  font-family: monospace;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: .22em;
+  color: var(--muted);
+}
+
+.doc {
+  margin-top: 1.4rem;
+  text-align: center;
+  font-size: .75rem;
+}
+.doc a { color: var(--bf); font-weight: 600; }

--- a/deploy/proxyAPI/pairing.html
+++ b/deploy/proxyAPI/pairing.html
@@ -1,226 +1,81 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Pairing</title>
-
-<style>
-  * { box-sizing: border-box; }
-
-  body {
-    font-family: monospace;
-    background: #f9f9f9;
-    margin: 0;
-    padding: 2rem;
-    display: flex;
-    justify-content: center;
-  }
-
-  .wrap {
-    width: 100%;
-    max-width: 520px;
-  }
-
-  /* LANG SWITCH */
-  #lang-switch {
-    margin-bottom: 1.5rem;
-  }
-
-  #lang-switch button {
-    margin-right: 8px;
-    padding: 10px 14px;
-    border-radius: 8px;
-    border: 1px solid #bbb;
-    background: #fff;
-    cursor: pointer;
-    font-size: 14px;
-  }
-
-  #lang-switch button[disabled] {
-    background: #e0e0e0;
-    color: #888;
-  }
-
-  /* TITLE */
-  h3 {
-    font-size: 1.6em;
-    margin-bottom: 1.2rem;
-  }
-
-  /* FORM */
-  form {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  input {
-    font-size: 2em;
-    padding: 14px 16px;
-    border-radius: 10px;
-    border: 1px solid #bbb;
-    background: #fff;
-    text-align: center;
-    letter-spacing: 0.25em;
-    font-family: monospace;
-    text-transform: uppercase; /* force visual uppercase */
-  }
-
-  button {
-    font-size: 1.3em;
-    padding: 14px;
-    border-radius: 10px;
-    border: 1px solid #bbb;
-    background: white;
-    cursor: pointer;
-    font-family: monospace;
-  }
-
-  button:active {
-    background: #e0e0e0;
-    transform: scale(0.98);
-  }
-
-  #hint {
-    margin-top: 12px;
-    font-size: 0.9em;
-    color: #888;
-    text-align: center;
-  }
-
-  /* error state for hint */
-  #hint.error {
-    color: #b00;
-    font-weight: 600;
-  }
-
-  @media (max-width: 420px) {
-    input { font-size: 1.6em; }
-    h3 { font-size: 1.3em; }
-  }
-</style>
+<link rel="stylesheet" href="/pairing/static/pairing.css">
 </head>
 
 <body>
 <div class="wrap">
-  <!-- LANG -->
-  <div id="lang-switch"></div>
 
-  <!-- TITLE -->
-  <h3 id="title">Enter pairing code</h3>
+  <header class="brand">
+    <img id="brand-logo" class="brand__logo" src="" alt="">
+    <div class="brand__text">
+      <div class="brand__name" id="brand-name"></div>
+      <div class="brand__tagline" id="brand-tagline"></div>
+    </div>
+  </header>
 
-  <!-- FORM -->
-  <form method="get" action="/interact" id="form">
-    <input id="pairingCode" name="pairingCode" required />
-    <button type="submit" id="btn">Submit</button>
-  </form>
+  <div class="toolbar">
+    <div class="segmented" role="radiogroup" aria-label="Langue">
+      <button type="button" class="segmented__el" id="lang-fr" role="radio">FR</button>
+      <button type="button" class="segmented__el" id="lang-en" role="radio">EN</button>
+    </div>
+    <button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false"></button>
+  </div>
 
-  <div id="msg" style="margin-top:12px;color:#b00;min-height:1.2em;"></div>
+  <h1 id="title"></h1>
 
-  <div id="hint">Enter the code shown on the device</div>
+  <div id="error-banner" class="banner banner--error" role="alert" hidden>
+    <span id="error-text"></span>
+    <button type="button" class="banner__close" id="error-close" aria-label="Fermer">&times;</button>
+  </div>
+
+  <p class="subtitle" id="subtitle"></p>
+
+  <!-- One box per character. The code is checked before going anywhere, so
+       there is no form to submit: an unknown code is answered here. -->
+  <div class="code" id="code-boxes" role="group"></div>
+
+  <button type="button" class="submit" id="btn" disabled>
+    <span class="spinner" id="spinner" hidden aria-hidden="true"></span>
+    <span id="btn-label"></span>
+  </button>
+
+  <section class="callout">
+    <h2 class="callout__title" id="hint-title"></h2>
+
+    <!-- An illustration of the room screen, not a code to type. Marked as such
+         and deliberately not code-shaped, so it cannot be mistaken for one. -->
+    <figure class="sample" aria-hidden="true">
+      <span class="sample__badge" id="sample-badge"></span>
+      <!-- Drawn, not encoded: it has to read as a QR code without being one,
+           so that no one tries to scan the illustration. -->
+      <!-- Drawn, not encoded: it has to read as a QR code without being one,
+           so that no one tries to scan the illustration. -->
+      <svg class="sample__qr" viewBox="0 0 25 25" aria-hidden="true">
+        <path class="qr-eye" d="M0 0h7v7H0zM1 1v5h5V1zM18 0h7v7h-7zM19 1v5h5V1zM0 18h7v7H0zM1 19v5h5v-5z"/>
+        <path class="qr-eye-in" d="M2 2h3v3H2zM20 2h3v3h-3zM2 20h3v3H2z"/>
+        <path class="qr-dot" d="M8 0h1v1h-1zM9 0h1v1h-1zM11 0h1v1h-1zM13 0h1v1h-1zM14 0h1v1h-1zM16 0h1v1h-1zM17 0h1v1h-1zM8 1h1v1h-1zM9 1h1v1h-1zM10 1h1v1h-1zM12 1h1v1h-1zM13 1h1v1h-1zM17 1h1v1h-1zM9 2h1v1h-1zM11 2h1v1h-1zM12 2h1v1h-1zM13 2h1v1h-1zM14 2h1v1h-1zM16 2h1v1h-1zM9 3h1v1h-1zM11 3h1v1h-1zM12 3h1v1h-1zM13 3h1v1h-1zM15 3h1v1h-1zM16 3h1v1h-1zM8 4h1v1h-1zM9 4h1v1h-1zM12 4h1v1h-1zM17 4h1v1h-1zM9 5h1v1h-1zM10 5h1v1h-1zM12 5h1v1h-1zM14 5h1v1h-1zM9 6h1v1h-1zM13 6h1v1h-1zM8 7h1v1h-1zM13 7h1v1h-1zM14 7h1v1h-1zM16 7h1v1h-1zM0 8h1v1h-1zM1 8h1v1h-1zM2 8h1v1h-1zM4 8h1v1h-1zM5 8h1v1h-1zM6 8h1v1h-1zM8 8h1v1h-1zM9 8h1v1h-1zM14 8h1v1h-1zM15 8h1v1h-1zM16 8h1v1h-1zM19 8h1v1h-1zM20 8h1v1h-1zM21 8h1v1h-1zM22 8h1v1h-1zM0 9h1v1h-1zM1 9h1v1h-1zM2 9h1v1h-1zM3 9h1v1h-1zM10 9h1v1h-1zM15 9h1v1h-1zM16 9h1v1h-1zM17 9h1v1h-1zM19 9h1v1h-1zM20 9h1v1h-1zM21 9h1v1h-1zM22 9h1v1h-1zM23 9h1v1h-1zM24 9h1v1h-1zM0 10h1v1h-1zM1 10h1v1h-1zM2 10h1v1h-1zM3 10h1v1h-1zM4 10h1v1h-1zM7 10h1v1h-1zM8 10h1v1h-1zM9 10h1v1h-1zM10 10h1v1h-1zM11 10h1v1h-1zM16 10h1v1h-1zM17 10h1v1h-1zM18 10h1v1h-1zM19 10h1v1h-1zM21 10h1v1h-1zM22 10h1v1h-1zM0 11h1v1h-1zM2 11h1v1h-1zM7 11h1v1h-1zM8 11h1v1h-1zM9 11h1v1h-1zM13 11h1v1h-1zM14 11h1v1h-1zM21 11h1v1h-1zM23 11h1v1h-1zM24 11h1v1h-1zM0 12h1v1h-1zM1 12h1v1h-1zM2 12h1v1h-1zM5 12h1v1h-1zM9 12h1v1h-1zM10 12h1v1h-1zM11 12h1v1h-1zM12 12h1v1h-1zM13 12h1v1h-1zM20 12h1v1h-1zM1 13h1v1h-1zM3 13h1v1h-1zM6 13h1v1h-1zM7 13h1v1h-1zM10 13h1v1h-1zM11 13h1v1h-1zM12 13h1v1h-1zM15 13h1v1h-1zM19 13h1v1h-1zM21 13h1v1h-1zM22 13h1v1h-1zM2 14h1v1h-1zM5 14h1v1h-1zM6 14h1v1h-1zM7 14h1v1h-1zM8 14h1v1h-1zM10 14h1v1h-1zM11 14h1v1h-1zM12 14h1v1h-1zM14 14h1v1h-1zM15 14h1v1h-1zM18 14h1v1h-1zM23 14h1v1h-1zM24 14h1v1h-1zM0 15h1v1h-1zM1 15h1v1h-1zM3 15h1v1h-1zM7 15h1v1h-1zM11 15h1v1h-1zM13 15h1v1h-1zM14 15h1v1h-1zM20 15h1v1h-1zM0 16h1v1h-1zM7 16h1v1h-1zM11 16h1v1h-1zM12 16h1v1h-1zM13 16h1v1h-1zM14 16h1v1h-1zM15 16h1v1h-1zM16 16h1v1h-1zM20 16h1v1h-1zM23 16h1v1h-1zM1 17h1v1h-1zM3 17h1v1h-1zM7 17h1v1h-1zM8 17h1v1h-1zM10 17h1v1h-1zM11 17h1v1h-1zM12 17h1v1h-1zM14 17h1v1h-1zM16 17h1v1h-1zM17 17h1v1h-1zM18 17h1v1h-1zM21 17h1v1h-1zM8 18h1v1h-1zM9 18h1v1h-1zM10 18h1v1h-1zM12 18h1v1h-1zM13 18h1v1h-1zM14 18h1v1h-1zM17 18h1v1h-1zM18 18h1v1h-1zM22 18h1v1h-1zM23 18h1v1h-1zM8 19h1v1h-1zM9 19h1v1h-1zM13 19h1v1h-1zM15 19h1v1h-1zM17 19h1v1h-1zM18 19h1v1h-1zM21 19h1v1h-1zM22 19h1v1h-1zM24 19h1v1h-1zM8 20h1v1h-1zM9 20h1v1h-1zM10 20h1v1h-1zM11 20h1v1h-1zM12 20h1v1h-1zM13 20h1v1h-1zM15 20h1v1h-1zM17 20h1v1h-1zM18 20h1v1h-1zM19 20h1v1h-1zM20 20h1v1h-1zM21 20h1v1h-1zM24 20h1v1h-1zM10 21h1v1h-1zM12 21h1v1h-1zM15 21h1v1h-1zM19 21h1v1h-1zM23 21h1v1h-1zM24 21h1v1h-1zM8 22h1v1h-1zM9 22h1v1h-1zM10 22h1v1h-1zM12 22h1v1h-1zM13 22h1v1h-1zM14 22h1v1h-1zM18 22h1v1h-1zM19 22h1v1h-1zM20 22h1v1h-1zM21 22h1v1h-1zM22 22h1v1h-1zM23 22h1v1h-1zM24 22h1v1h-1zM11 23h1v1h-1zM13 23h1v1h-1zM14 23h1v1h-1zM15 23h1v1h-1zM16 23h1v1h-1zM19 23h1v1h-1zM21 23h1v1h-1zM22 23h1v1h-1zM23 23h1v1h-1zM24 23h1v1h-1zM8 24h1v1h-1zM9 24h1v1h-1zM10 24h1v1h-1zM11 24h1v1h-1zM18 24h1v1h-1zM19 24h1v1h-1zM21 24h1v1h-1zM24 24h1v1h-1z"/>
+      </svg>
+      <div class="sample__text">
+        <span class="sample__from" id="sample-from"></span>
+        <span class="sample__code">ABCD1</span>
+        <span class="sample__url" id="sample-url"></span>
+      </div>
+    </figure>
+
+    <p class="callout__text" id="hint-text"></p>
+    <p class="callout__note" id="hint-warning"></p>
+  </section>
+
+  <p class="doc">
+    <a id="doc-link" href="" target="_blank" rel="noopener"></a>
+  </p>
+
 </div>
-
-<script>
-let lang = localStorage.getItem("lang") || "fr";
-
-const texts = {
-  fr: {
-    title: "Entrer le code de jumelage",
-    placeholder: "Code de jumelage",
-    button: "Valider",
-    hint: "Entrez le code affiché sur l'appareil",
-    invalid_pairing: "Code d'appairage invalide."
-  },
-  en: {
-    title: "Enter pairing code",
-    placeholder: "Pairing code",
-    button: "Submit",
-    hint: "Enter the code shown on the device",
-    invalid_pairing: "Invalid pairing code"
-  }
-};
-
-// read server-injected vars early (may be undefined)
-const serverError = window.SERVER_ERROR || null;
-const serverPairingCode = window.SERVER_PAIRING_CODE || null;
-
-// store URL error if present
-let urlError = false;
-let urlErrorText = null;
-
-function render() {
-  const sw = document.getElementById("lang-switch");
-
-  sw.innerHTML = `
-    <button onclick="setLang('fr')" ${lang === 'fr' ? 'disabled' : ''}>🇫🇷 Français</button>
-    <button onclick="setLang('en')" ${lang === 'en' ? 'disabled' : ''}>🇬🇧 English</button>
-  `;
-
-  document.getElementById("title").textContent = texts[lang].title;
-  document.getElementById("pairingCode").placeholder = texts[lang].placeholder;
-  document.getElementById("btn").textContent = texts[lang].button;
-
-  const hintEl = document.getElementById("hint");
-  if (serverError) {
-    hintEl.textContent = texts[lang].invalid_pairing;
-    hintEl.classList.add('error');
-  } else if (urlError) {
-    hintEl.textContent = urlErrorText || texts[lang].invalid_pairing;
-    hintEl.classList.add('error');
-  } else {
-    hintEl.textContent = texts[lang].hint;
-    hintEl.classList.remove('error');
-  }
-}
-
-function setLang(l) {
-  lang = l;
-  localStorage.setItem("lang", l);
-  render();
-}
-
-/* UX improvements */
-const input = document.getElementById("pairingCode");
-const form = document.getElementById("form");
-const msg = document.getElementById("msg");
-
-input.focus();
-
-input.addEventListener("input", () => {
-  input.placeholder = "";
-  // enforce uppercase in the value (real, not only visual)
-  const pos = input.selectionStart;
-  input.value = input.value.toUpperCase();
-  try { input.setSelectionRange(pos, pos); } catch(e) {}
-});
-
-form.addEventListener("submit", () => {
-  input.value = input.value.trim();
-});
-
-// show server-provided error and/or prefill pairingCode from query params
-(function handleQueryParams(){
-  // prefill from server injection (preferred) or from query params
-  if (serverPairingCode) {
-    input.value = String(serverPairingCode).toUpperCase();
-    input.focus();
-    return;
-  }
-  const p = new URLSearchParams(window.location.search);
-  if (p.has('pairingCode')) {
-    input.value = p.get('pairingCode').toUpperCase();
-  }
-  // if error param present, store for render() and mark red
-  if (p.has('error')) {
-    urlError = true;
-    try { urlErrorText = decodeURIComponent(p.get('error')); } catch(e) { urlErrorText = p.get('error'); }
-    input.focus();
-  }
- })();
-
-render();
-</script>
-
+<script src="/pairing/static/pairing.js"></script>
 </body>
 </html>

--- a/deploy/proxyAPI/pairing.js
+++ b/deploy/proxyAPI/pairing.js
@@ -1,0 +1,299 @@
+// ---------------------------------------------------------------------------
+// Per-deployment settings. The service is white-labelled — VisioHub at RENATER,
+// Visiby Connect on NUBO — so the name, the logo and the documentation link are
+// gathered here rather than scattered through the markup.
+// ---------------------------------------------------------------------------
+const BRAND = {
+  name: 'SIPMediaGW',
+  tagline: '',
+  logo: '',                       // e.g. '/pairing/static/logo.svg'; empty hides it
+  docUrl: '',                     // empty hides the documentation link
+  docLabelFr: 'Documentation et présentation du service',
+  docLabelEn: 'Service documentation and overview',
+};
+
+const CODE_LENGTH = 5;
+
+const TEXTS = {
+  fr: {
+    title: 'Contrôler votre réunion',
+    subtitle: "Saisissez le code affiché à l'écran",
+    button: 'Valider',
+    hintTitle: 'Où trouver le code ?',
+    hint: "Ce code à 5 caractères s'affiche sur l'écran de la salle, à côté du QR code.",
+    warning: "Attention, il change régulièrement : vérifiez qu'il est toujours le même avant de valider.",
+    sample: 'Exemple',
+    sampleFrom: 'Depuis votre téléphone',
+    close: 'Fermer ce message',
+    errorPrefix: 'Le code',
+    errorSuffix: 'est erroné ou expiré, veuillez réessayer.',
+    themeToLight: 'Passer en thème clair',
+    themeToDark: 'Passer en thème sombre',
+    boxLabel: (i) => `Caractère ${i + 1} sur ${CODE_LENGTH}`,
+  },
+  en: {
+    title: 'Control your meeting',
+    subtitle: 'Enter the code shown on screen',
+    button: 'Submit',
+    hintTitle: 'Where to find the code?',
+    hint: 'This 5-character code is shown on the room screen, next to the QR code.',
+    warning: 'Note: it changes regularly — make sure it still matches before submitting.',
+    sample: 'Example',
+    sampleFrom: 'From your phone',
+    close: 'Dismiss this message',
+    errorPrefix: 'Code',
+    errorSuffix: 'is invalid or expired, please try again.',
+    themeToLight: 'Switch to light theme',
+    themeToDark: 'Switch to dark theme',
+    boxLabel: (i) => `Character ${i + 1} of ${CODE_LENGTH}`,
+  },
+};
+
+// The code the proxy turned down, quoted back in the error message. The boxes
+// are cleared rather than kept: a refused code is not worth correcting one
+// character at a time, re-reading it from the room screen is the point.
+let rejectedCode = '';
+
+let lang = localStorage.getItem('lang') || 'fr';
+if (!TEXTS[lang]) lang = 'fr';
+
+// The banner stays until it is closed rather than fading on a timer: it names
+// the code that was turned down, and the reader may need it while checking the
+// room screen.
+let dismissed = false;
+
+let dark = localStorage.getItem('theme')
+  ? localStorage.getItem('theme') === 'dark'
+  : window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+const $ = (id) => document.getElementById(id);
+const boxes = [];
+
+// --- code entry ------------------------------------------------------------
+
+function buildBoxes() {
+  const wrap = $('code-boxes');
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    const box = document.createElement('input');
+    box.type = 'text';
+    box.inputMode = 'text';
+    box.autocomplete = 'off';
+    box.autocapitalize = 'characters';
+    box.spellcheck = false;
+    box.maxLength = 1;
+    box.addEventListener('input', () => onInput(i));
+    box.addEventListener('keydown', (e) => onKeyDown(e, i));
+    box.addEventListener('paste', onPaste);
+    wrap.appendChild(box);
+    boxes.push(box);
+  }
+}
+
+function onInput(i) {
+  const box = boxes[i];
+  // The code is uppercase letters and digits; anything else is dropped rather
+  // than rejected, so a stray keystroke does not interrupt the entry.
+  box.value = box.value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(-1);
+  if (box.value && i < CODE_LENGTH - 1) boxes[i + 1].focus();
+  refresh();
+}
+
+function onKeyDown(e, i) {
+  if (e.key === 'Backspace' && !boxes[i].value && i > 0) {
+    boxes[i - 1].focus();
+  } else if (e.key === 'ArrowLeft' && i > 0) {
+    e.preventDefault();
+    boxes[i - 1].focus();
+  } else if (e.key === 'ArrowRight' && i < CODE_LENGTH - 1) {
+    e.preventDefault();
+    boxes[i + 1].focus();
+  }
+}
+
+// A code copied from elsewhere arrives in one box: spread it across all of them.
+function onPaste(e) {
+  e.preventDefault();
+  const text = (e.clipboardData || window.clipboardData).getData('text');
+  setCode(text);
+}
+
+function setCode(value) {
+  const chars = String(value).toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, CODE_LENGTH);
+  boxes.forEach((box, i) => { box.value = chars[i] || ''; });
+  refresh();
+  const next = chars.length < CODE_LENGTH ? chars.length : CODE_LENGTH - 1;
+  boxes[next].focus();
+}
+
+function code() {
+  return boxes.map((b) => b.value).join('');
+}
+
+function refresh() {
+  const complete = code().length === CODE_LENGTH;
+  boxes.forEach((b) => b.classList.toggle('filled', !!b.value));
+  $('btn').disabled = !complete;
+}
+
+// --- rendering -------------------------------------------------------------
+
+function render() {
+  const t = TEXTS[lang];
+
+  document.documentElement.lang = lang;
+  document.documentElement.dataset.theme = dark ? 'dark' : 'light';
+
+  $('lang-fr').setAttribute('aria-checked', String(lang === 'fr'));
+  $('lang-en').setAttribute('aria-checked', String(lang === 'en'));
+
+  const toggle = $('theme-toggle');
+  toggle.textContent = dark ? '☀' : '☾';
+  toggle.setAttribute('aria-pressed', String(dark));
+  toggle.setAttribute('aria-label', dark ? t.themeToLight : t.themeToDark);
+
+  $('title').textContent = t.title;
+  $('subtitle').textContent = t.subtitle;
+  $('btn-label').textContent = t.button;
+  $('hint-title').textContent = t.hintTitle;
+  $('hint-text').textContent = t.hint;
+  $('hint-warning').textContent = t.warning;
+  $('sample-badge').textContent = t.sample;
+  $('sample-from').textContent = t.sampleFrom;
+
+  boxes.forEach((box, i) => box.setAttribute('aria-label', t.boxLabel(i)));
+
+  // The rejected code is named in the message: on a screen where five boxes
+  // now sit empty, "this code" alone would leave the reader wondering which.
+  const banner = $('error-banner');
+  banner.hidden = !rejectedCode || dismissed;
+  if (rejectedCode) {
+    const text = $('error-text');
+    text.textContent = '';
+    text.append(t.errorPrefix + ' ');
+    const codeEl = document.createElement('b');
+    codeEl.textContent = rejectedCode;
+    text.append(codeEl, ' ' + t.errorSuffix);
+    $('error-close').setAttribute('aria-label', t.close);
+  }
+
+  // The address the room screen shows under the code. Taken from where the
+  // visitor already is, so the illustration matches their own deployment.
+  $('sample-url').textContent = window.location.host;
+
+  const link = $('doc-link');
+  if (BRAND.docUrl) {
+    link.href = BRAND.docUrl;
+    link.textContent = lang === 'fr' ? BRAND.docLabelFr : BRAND.docLabelEn;
+  } else {
+    link.parentElement.hidden = true;
+  }
+}
+
+function applyBrand() {
+  $('brand-name').textContent = BRAND.name;
+  $('brand-tagline').textContent = BRAND.tagline;
+  if (BRAND.logo) {
+    const logo = $('brand-logo');
+    logo.src = BRAND.logo;
+    logo.alt = BRAND.name;
+  }
+}
+
+function setLang(value) {
+  lang = value;
+  localStorage.setItem('lang', value);
+  render();
+}
+
+// --- startup ---------------------------------------------------------------
+
+buildBoxes();
+applyBrand();
+
+$('lang-fr').addEventListener('click', () => setLang('fr'));
+$('lang-en').addEventListener('click', () => setLang('en'));
+// A click in the gaps between boxes lands on the strip itself; send it to the
+// first box still waiting for a character.
+$('code-boxes').addEventListener('mousedown', (e) => {
+  if (e.target !== e.currentTarget) return;   // a box was clicked, leave it be
+  e.preventDefault();
+  const next = boxes.find((b) => !b.value) || boxes[CODE_LENGTH - 1];
+  next.focus();
+});
+
+$('error-close').addEventListener('click', () => {
+  dismissed = true;
+  $('error-banner').hidden = true;
+});
+
+$('theme-toggle').addEventListener('click', () => {
+  dark = !dark;
+  localStorage.setItem('theme', dark ? 'dark' : 'light');
+  render();
+});
+
+// The code is checked before going anywhere: the page asks the proxy, and
+// only navigates once it knows the code is live. A refused one is answered
+// here, without a round trip that would leave the address bar on a page the
+// visitor is not looking at.
+async function submit() {
+  const value = code();
+  if (value.length !== CODE_LENGTH) return;
+
+  $('spinner').hidden = false;
+  $('btn').disabled = true;
+  rejectedCode = '';
+  dismissed = false;
+  render();
+
+  let gwId = null;
+  try {
+    const res = await fetch('/pairing/resolve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: value }),
+    });
+    if (res.ok) gwId = (await res.json())?.data?.gw_id || null;
+  } catch (e) {
+    // Unreachable proxy reads the same as a refused code here: either way the
+    // visitor has nothing to do but try again.
+  }
+
+  if (gwId) {
+    // The spinner keeps running until the browser leaves the page.
+    window.location.href = '/interact?gwId=' + encodeURIComponent(gwId);
+    return;
+  }
+
+  rejectedCode = value;
+  $('spinner').hidden = true;
+  boxes.forEach((b) => { b.value = ''; });
+  refresh();
+  render();
+  boxes[0].focus();
+}
+
+$('btn').addEventListener('click', submit);
+
+// Coming back with the browser's Back button restores the page from its cache,
+// spinner still turning and boxes still filled, without re-running any of this.
+// pageshow fires on that restore too, which is where the entry is reset.
+window.addEventListener('pageshow', (e) => {
+  if (!e.persisted) return;
+  $('spinner').hidden = true;
+  rejectedCode = '';
+  dismissed = false;
+  boxes.forEach((b) => { b.value = ''; });
+  refresh();
+  render();
+  boxes[0].focus();
+});
+
+// Enter anywhere in the strip submits, as a form would have.
+$('code-boxes').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') { e.preventDefault(); submit(); }
+});
+
+render();
+refresh();
+boxes[0].focus();

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -91,6 +91,24 @@ def adminUnauthorized():
 adminStaticFiles = {"admin.css": "text/css", "admin.js": "application/javascript",
                     "favicon.svg": "image/svg+xml"}
 
+# The pairing page's stylesheet and script. Served without a check, like the
+# page itself: the pairing code is what grants access, and it is entered on
+# that page.
+pairingStaticFiles = {"pairing.css": "text/css", "pairing.js": "application/javascript"}
+
+
+@app.get("/pairing/static/{file_name}")
+async def pairing_static(file_name: str):
+    """Serve the pairing page's CSS/JS (whitelist, no directory access)."""
+    mediaType = pairingStaticFiles.get(file_name)
+    if not mediaType:
+        return JSONResponse(status_code=404, content={"detail": "not found"})
+    try:
+        with open(os.path.join(assetDir, file_name), "r", encoding="utf-8") as f:
+            return Response(content=f.read(), media_type=mediaType)
+    except FileNotFoundError:
+        return JSONResponse(status_code=404, content={"detail": f"{file_name} not found"})
+
 @app.get("/admin/")
 async def admin_page(request: Request):
     """
@@ -520,25 +538,13 @@ async def interact(request: Request):
                 redirectUrl = "{}?gwId={}".format(str(request.url).split('?')[0], resolvedGwId)
                 return RedirectResponse(url=redirectUrl, status_code=302)
             else:
-                # Return pairing.html and inject a JS var so the page can display a translated error
-                try:
-                    with open(os.path.join(assetDir, "pairing.html"), "r", encoding="utf-8") as f:
-                        html_form = f.read()
-                except FileNotFoundError:
-                    raise HTTPException(status_code=500, detail="pairing.html not found on server")
-                # inject safe JS literals
-                error_msg = "Invalid pairing code"
-                injection_script = (
-                    f'<script>window.SERVER_ERROR = {json.dumps(error_msg)}; '
-                    f'window.SERVER_PAIRING_CODE = {json.dumps(pairingCode)};</script>'
-                )
-                # insert the script before the first existing <script> so the page's JS sees it
-                if "<script" in html_form:
-                    html_with_msg = html_form.replace("<script", injection_script + "<script", 1)
-                else:
-                    # fallback: insert before </head>
-                    html_with_msg = html_form.replace("</head>", injection_script + "</head>", 1)
-                return Response(content=html_with_msg, media_type="text/html")
+                # The pairing page used to be returned here with the error
+                # injected into its markup, which left the address bar on
+                # /interact while showing the pairing form — and a reload
+                # retried the code that had just been turned down. The visitor
+                # is sent to the pairing page instead, which now checks a code
+                # through /pairing/resolve before going anywhere.
+                return RedirectResponse(url="/pairing", status_code=302)
         else:
             with open(os.path.join(assetDir, "pairing.html"), "r", encoding="utf-8") as f:
                 html_form = f.read()


### PR DESCRIPTION
The page was 226 lines of markup, style and script in one file, and it asked the proxy a question by navigating to it: the code went out as a form submit to /interact, and a refused one came back as this page under the wrong address, its error injected into the markup as a <script>.

It is now three files — pairing.html, pairing.css, pairing.js — served by the proxy alongside admin's, through a whitelist of those two names. No gw_id is involved: the pairing page is public by design, the code is what grants access and it is entered here.

Entry is five boxes rather than one field, advancing as you type, taking a pasted code across all five, and accepting lower case. Clicking the gaps between them puts the caret in the first empty one. The code is checked through POST /pairing/resolve before going anywhere, so a refused code is answered on the spot: the message names it, the boxes clear, and the address bar never shows a page the visitor is not on. Coming back with the Back button resets the entry, which a restored page would otherwise leave filled with a spinner still turning.

The page also gains a dark theme, following the system preference until the visitor picks one.

Two things go from proxy.py: the injected <script>, and the branch that served this page from /interact — a refused code redirects to /pairing now. The deployment-specific name, logo and documentation link are gathered in one block at the top of the script rather than spread through the markup.

Tested end to end: valid code, refused code, lower case, paste, Back button, both languages, both themes.