### PR TITLE
[Added] let the room change the name the conference shows

### DIFF
--- a/deploy/proxyAPI/interact-connexion.css
+++ b/deploy/proxyAPI/interact-connexion.css
@@ -155,3 +155,46 @@
 .platforms.is-waiting { opacity: .45; }
 .platform:disabled { cursor: default; }
 .platform:disabled:hover { box-shadow: inset 0 0 0 1px var(--border); }
+
+/* Editing the name the conference shows */
+.room__line { display: flex; align-items: center; gap: .35rem; flex-wrap: wrap; }
+.room__edit {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex: none;
+  border: 0;
+  border-radius: .25rem;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.room__edit svg { width: .85rem; height: .85rem; fill: currentColor; }
+.room__edit:hover { background: var(--bg); color: var(--bf); }
+.room__input {
+  flex: 1 1 4rem;
+  min-width: 0;
+  min-height: 1.9rem;
+  padding: .1rem .45rem;
+  border: 0;
+  border-radius: .25rem;
+  background: var(--bg);
+  box-shadow: inset 0 0 0 1.5px var(--bf);
+  color: var(--txt);
+  font: inherit;
+  font-size: .8rem;
+}
+.room__save, .room__cancel {
+  min-height: 1.9rem;
+  padding: 0 .45rem;
+  white-space: nowrap;
+  border: 0;
+  border-radius: .25rem;
+  font: inherit;
+  font-size: .75rem;
+  cursor: pointer;
+}
+.room__save { background: var(--bf); color: #fff; font-weight: 600; }
+.room__cancel { background: transparent; box-shadow: inset 0 0 0 1px var(--border); color: var(--txt); }

--- a/deploy/proxyAPI/interact.html
+++ b/deploy/proxyAPI/interact.html
@@ -3,7 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>SIPMediaGW Remote Control</title>
+<!-- Replaced at load with the deployment name, so both pages carry the
+     same one. This is what shows before the script runs. -->
+<title>SIPMediaGW</title>
 <link rel="stylesheet" href="/interact/static/shared.css">
 <link rel="stylesheet" href="/interact/static/interact-connexion.css">
 <link rel="stylesheet" href="/interact/static/interact-controls.css">
@@ -30,8 +32,18 @@
   <!-- Which room this page drives, so the visitor can tell they reached the
        right one. Filled from the first status poll. -->
   <section class="room room--pending" id="room" aria-live="polite">
-    <div><span class="room__label" id="room-name-label"></span>
-         <span class="room__value" id="room-name"></span></div>
+    <div class="room__line">
+      <span class="room__label" id="room-name-label"></span>
+      <span class="room__value" id="room-name"></span>
+      <!-- The name shown to the other participants. It starts out as the
+           endpoint's own but does not have to stay it. -->
+      <button type="button" class="room__edit" id="name-edit" hidden>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.2V21h3.8L17.8 10 14 6.2 3 17.2zM20.7 7a1 1 0 0 0 0-1.4l-2.3-2.3a1 1 0 0 0-1.4 0l-1.8 1.8L18.9 8.8l1.8-1.8z"/></svg>
+      </button>
+      <input class="room__input" id="name-input" hidden autocomplete="off" maxlength="64">
+      <button type="button" class="room__save" id="name-save" hidden></button>
+      <button type="button" class="room__cancel" id="name-cancel" hidden></button>
+    </div>
     <div><span class="room__label" id="room-uri-label"></span>
          <span class="room__value" id="room-uri"></span></div>
   </section>
@@ -104,7 +116,7 @@
   <div id="slide-controls" aria-hidden="false">
     <div class="controls-row">
       <button id="btn-slideShot" type="button" class="key" tabindex="-1"
-              title="Capture slide" aria-label="Capture slide">Capture</button>
+              data-tip="Capture slide" aria-label="Capture slide">Capture</button>
       <div id="slide-hint" style="font-size:12px;color:#666;">Thumbnails appear here</div>
     </div>
     <div id="slide-gallery" aria-live="polite"></div>
@@ -118,8 +130,8 @@
 <div id="slide-preview" aria-hidden="true">
     <div class="preview-actions">
       <a id="slide-download" class="key small" href="#" download="slide.png">Download</a>
-      <button id="slide-fullscreen" class="key small" title="Fullscreen">Full screen</button>
-      <button id="slide-discard" class="key small" title="Discard">Discard</button>
+      <button id="slide-fullscreen" class="key small" data-tip="Fullscreen">Full screen</button>
+      <button id="slide-discard" class="key small" data-tip="Discard">Discard</button>
       <button id="slide-close" class="key small">Close</button>
     </div>
     <img id="slide-img" src="" alt="Slide capture">

--- a/deploy/proxyAPI/interact.js
+++ b/deploy/proxyAPI/interact.js
@@ -33,6 +33,9 @@ const TEXTS = {
     roomUri: 'Adresse vidéo :',
     connecting: 'connexion en cours…',
     waiting: 'En attente de la connexion d\u2019un terminal de visioconf\u00e9rence.',
+    editName: 'Modifier le nom affich\u00e9 dans la conf\u00e9rence',
+    save: 'Valider',
+    cancel: 'Annuler',
     meetingLabel: 'Veuillez saisir l\u2019identifiant de la r\u00e9union',
     meetingFallback: 'Entrez le nom de la réunion',
     join: 'Rejoindre',
@@ -53,6 +56,9 @@ const TEXTS = {
     roomUri: 'Video address:',
     connecting: 'connecting…',
     waiting: 'Waiting for a room endpoint to call in.',
+    editName: 'Change the name shown in the conference',
+    save: 'Save',
+    cancel: 'Cancel',
     meetingLabel: 'Please enter the meeting id',
     meetingFallback: 'Enter the meeting name',
     join: 'Join',
@@ -73,6 +79,20 @@ let dark = localStorage.getItem('theme')
   : window.matchMedia('(prefers-color-scheme: dark)').matches;
 
 const $ = (id) => document.getElementById(id);
+
+// A tooltip is centred on its element, which puts it off the page when the
+// element sits near an edge - and where it sits depends on the text beside it.
+// The side is therefore chosen as the pointer arrives, not written into the
+// markup.
+document.addEventListener('mouseover', (e) => {
+  const el = e.target.closest('[data-tip]');
+  if (!el) return;
+  const box = el.getBoundingClientRect();
+  const half = 0.5 * Math.min(window.innerWidth, 320);   // a tooltip's worst case
+  delete el.dataset.tipAlign;
+  if (box.left + box.width / 2 < half) el.dataset.tipAlign = 'left';
+  else if (window.innerWidth - box.right + box.width / 2 < half) el.dataset.tipAlign = 'right';
+}, true);
 
 // defined early so the startup callback below can call it
 function updateSlideControlsVisibility() {
@@ -127,6 +147,7 @@ function renderLangSwitch() {
   toggle.setAttribute('aria-pressed', String(dark));
   toggle.setAttribute('aria-label', dark ? t.themeToLight : t.themeToDark);
 
+  document.title = BRAND.name;
   $('brand-name').textContent = BRAND.name;
   $('brand-tagline').textContent = BRAND.tagline;
   if (BRAND.logo) { $('brand-logo').src = BRAND.logo; $('brand-logo').alt = BRAND.name; }
@@ -134,6 +155,10 @@ function renderLangSwitch() {
   $('title-text').textContent = t.title;
   $('platforms-subtitle').textContent = t.pickPlatform;
   $('waiting').textContent = t.waiting;
+  $('name-edit').dataset.tip = t.editName;
+  $('name-edit').setAttribute('aria-label', t.editName);
+  $('name-save').textContent = t.save;
+  $('name-cancel').textContent = t.cancel;
   $('room-name-label').textContent = t.roomName;
   $('room-uri-label').textContent = t.roomUri;
   $('btn-enter-label').textContent = t.join;
@@ -141,7 +166,7 @@ function renderLangSwitch() {
   const endBtn = $('btn-endcall');
   if (endBtn) {
     endBtn.textContent = t.hangUp;
-    endBtn.title = t.hangUpTitle;
+    endBtn.dataset.tip = t.hangUpTitle;
   }
   $('confirm-title').textContent = t.confirmTitle;
   $('confirm-body').textContent = t.confirmBody;
@@ -178,16 +203,62 @@ function showScreen(name) {
 let roomName = '';
 let roomUri = '';
 
+// The name the conference shows. It starts out as the endpoint's own — which
+// is why the two usually match — but it is a separate value, and the only one
+// of the pair the room may change.
+let displayName = null;
+
 // Set once a hang-up has been asked for. The status poll clears room and
 // browsing before gw_state turns to stopped, so without this the page would
 // drop back to the platform list for a poll or two on its way out.
 let leaving = false;
 
+async function fetchDisplayName() {
+  if (!gwId) return;
+  try {
+    const res = await fetch(apiUrl('/command'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gw_id: gwId, payload: { command: 'displayName' } }),
+    });
+    if (!res.ok) return;
+    const json = await res.json();
+    displayName = json?.data?.displayName || json?.data?.displayname || '';
+    showRoom();
+  } catch (e) {
+    // Left as null: the line then falls back to the endpoint's own name.
+  }
+}
+
+async function sendDisplayName(name) {
+  if (!gwId) return;
+  await sendCommand('displayName', name, {
+    successLabel: `display name: ${name}`,
+    startPolling: false,
+  });
+  displayName = name;
+  showRoom();
+}
+
+function startEditName() {
+  $('name-input').value = displayName || roomName || '';
+  ['room-name', 'name-edit'].forEach((id) => { $(id).hidden = true; });
+  ['name-input', 'name-save', 'name-cancel'].forEach((id) => { $(id).hidden = false; });
+  $('name-input').focus();
+  $('name-input').select();
+}
+
+function stopEditName() {
+  ['name-input', 'name-save', 'name-cancel'].forEach((id) => { $(id).hidden = true; });
+  $('room-name').hidden = false;
+  $('name-edit').hidden = false;
+}
+
 function showRoom() {
   const t = TEXTS[currentLang];
   const known = !!(roomName || roomUri);
   $('room').classList.toggle('room--pending', !known);
-  $('room-name').textContent = roomName || t.connecting;
+  $('room-name').textContent = displayName || roomName || t.connecting;
   $('room-uri').textContent = roomUri || t.connecting;
 
   // Until an endpoint has called in there is nothing on the other end: a
@@ -197,6 +268,9 @@ function showRoom() {
   $('platforms').querySelectorAll('button').forEach((b) => { b.disabled = !known; });
   $('btn-endcall').disabled = !known;
   $('waiting').hidden = known;
+  // Nothing to rename until an endpoint is on the line.
+  if (!known) stopEditName();
+  $('name-edit').hidden = !known || !$('name-input').hidden;
 }
 
 const capture = document.getElementById('key-capture');
@@ -450,9 +524,13 @@ async function checkGwStatus() {
     const peerName = statusData.data.peer_name || '';
     const peerUri = statusData.data.peer_uri || '';
     if (peerName !== roomName || peerUri !== roomUri) {
+      const first = !roomName && !roomUri;
       roomName = peerName;
       roomUri = peerUri;
       showRoom();
+      // Read once, when the endpoint first appears: the name it announced is
+      // the starting point, whatever it had been set to before.
+      if (first && (peerName || peerUri)) fetchDisplayName();
     }
 
     let bn = statusData.data.browsing;
@@ -617,6 +695,18 @@ function closeConfirm() {
   $('confirm').hidden = true;
   $('btn-endcall').focus();
 }
+
+$('name-edit').onclick = startEditName;
+$('name-cancel').onclick = stopEditName;
+$('name-save').onclick = async () => {
+  const value = $('name-input').value.trim();
+  stopEditName();
+  if (value) await sendDisplayName(value);
+};
+$('name-input').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') { e.preventDefault(); $('name-save').click(); }
+  if (e.key === 'Escape') { e.preventDefault(); stopEditName(); }
+});
 
 $('btn-endcall').onclick = askToHangUp;
 $('confirm-no').onclick = closeConfirm;

--- a/deploy/proxyAPI/pairing.html
+++ b/deploy/proxyAPI/pairing.html
@@ -3,7 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Pairing</title>
+<!-- Replaced at load with the deployment name. -->
+<title>SIPMediaGW</title>
 <link rel="stylesheet" href="/pairing/static/shared.css">
 <link rel="stylesheet" href="/pairing/static/pairing.css">
 </head>

--- a/deploy/proxyAPI/pairing.js
+++ b/deploy/proxyAPI/pairing.js
@@ -67,6 +67,20 @@ let dark = localStorage.getItem('theme')
   : window.matchMedia('(prefers-color-scheme: dark)').matches;
 
 const $ = (id) => document.getElementById(id);
+
+// A tooltip is centred on its element, which puts it off the page when the
+// element sits near an edge - and where it sits depends on the text beside it.
+// The side is therefore chosen as the pointer arrives, not written into the
+// markup.
+document.addEventListener('mouseover', (e) => {
+  const el = e.target.closest('[data-tip]');
+  if (!el) return;
+  const box = el.getBoundingClientRect();
+  const half = 0.5 * Math.min(window.innerWidth, 320);   // a tooltip's worst case
+  delete el.dataset.tipAlign;
+  if (box.left + box.width / 2 < half) el.dataset.tipAlign = 'left';
+  else if (window.innerWidth - box.right + box.width / 2 < half) el.dataset.tipAlign = 'right';
+}, true);
 const boxes = [];
 
 // --- code entry ------------------------------------------------------------
@@ -190,6 +204,7 @@ function render() {
 }
 
 function applyBrand() {
+  document.title = BRAND.name;
   $('brand-name').textContent = BRAND.name;
   $('brand-tagline').textContent = BRAND.tagline;
   if (BRAND.logo) {

--- a/deploy/proxyAPI/shared.css
+++ b/deploy/proxyAPI/shared.css
@@ -267,3 +267,56 @@ h1 {
 }
 .modal__btn--danger:hover { background: var(--bf-hover, var(--bf)); filter: brightness(1.1); }
 .modal__btn:disabled { opacity: .5; cursor: default; }
+
+/* Tooltips. The browser's own arrive late, sit where they like and ignore the
+   page's styling; these follow the palette and appear at once. They hang below
+   the element rather than above, where a header or a toolbar would sit on top
+   of them. Anything with a data-tip gets one — keep the text short, a tooltip
+   is a reminder, not a sentence. */
+[data-tip] { position: relative; }
+[data-tip]::after {
+  content: attr(data-tip);
+  position: absolute;
+  top: calc(100% + .5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  padding: .35rem .6rem;
+  border-radius: .25rem;
+  background: var(--bg);
+  box-shadow: 0 0 0 1px var(--border), 0 2px 8px rgba(0, 0, 18, .12);
+  color: var(--txt);
+  font-size: .72rem;
+  font-weight: 400;
+  line-height: 1.3;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .1s;
+}
+[data-tip]::before {
+  content: "";
+  position: absolute;
+  top: calc(100% + .15rem);
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  z-index: 21;
+  width: .5rem;
+  height: .5rem;
+  background: var(--bg);
+  box-shadow: -1px -1px 0 0 var(--border);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .1s;
+}
+[data-tip]:hover::after, [data-tip]:hover::before,
+[data-tip]:focus-visible::after, [data-tip]:focus-visible::before { opacity: 1; }
+
+/* Centred, a tooltip on an element near an edge runs off the page. Which edge
+   depends on where the element lands, which depends on the text beside it, so
+   the side is picked as the pointer arrives rather than written into the
+   markup — see the handler in the page's script. */
+[data-tip][data-tip-align="left"]::after { left: 0; transform: none; }
+[data-tip][data-tip-align="left"]::before { left: .75rem; }
+[data-tip][data-tip-align="right"]::after { left: auto; right: 0; transform: none; }
+[data-tip][data-tip-align="right"]::before { left: auto; right: .75rem; }


### PR DESCRIPTION
The companion page rework dropped the display name field along with the input row it sat in. That was a mistake: the name shown to the other participants starts out as the endpoint's own — which is why the two usually match — but it is a separate value, and the only one of the pair the room may choose.

A pencil beside the room name opens it for editing; Enter or Save sends it, Escape or Cancel closes. The SIP address stays read-only: it is what the endpoint is, not what it calls itself. The pencil appears only once an endpoint has called in, like the rest of the controls on that screen.

The name is read once, when the endpoint first shows up, through the displayName command the launcher already answers — the same one the page used before.

Two things come along, both touching the pairing page as well. The tab title now comes from the deployment name rather than being "Pairing" on one page and "SIPMediaGW Remote Control" on the other. And tooltips are drawn by the page instead of the browser: the native ones arrive late, sit where they like and ignore the styling. They hang below their element, since a header would otherwise cover them, and pick their side from the room left — a long room name pushes the pencil to the edge.

Tested: editing from both screens, the name landing in the conference, the pencil absent before an endpoint calls in, both languages, both themes, and tooltips at three window widths with a short and a long room name.