### PR TITLE
[Changed] point the room screen at the pairing page

### DIFF
--- a/.env
+++ b/.env
@@ -84,7 +84,7 @@ GW_PROXY_REG_TIMEOUT=${GW_PROXY_REG_TIMEOUT:-30}
 GW_REVERSE_PROXY=${GW_REVERSE_PROXY:-http://$HOST_IP:9000}
 PROXY_TOKEN=${PROXY_TOKEN:-1234}
 
-QR_CODE_URL="{reverse_proxy}/interact?pairingCode={code}"
+QR_CODE_URL="{reverse_proxy}/?pairingCode={code}"
 PAIRING_CODE_TIMEOUT=${PAIRING_CODE_TIMEOUT:-90} # Should be a multiple of GW_PROXY_REG_TIMEOUT
 
 ## Streaming

--- a/deploy/proxyAPI/pairing.js
+++ b/deploy/proxyAPI/pairing.js
@@ -309,6 +309,12 @@ $('code-boxes').addEventListener('keydown', (e) => {
   if (e.key === 'Enter') { e.preventDefault(); submit(); }
 });
 
+// A code in the query comes from the room screen, either scanned or typed from
+// the address printed under the QR. It is filled in rather than left for the
+// visitor to copy; submitting stays theirs to do.
+const fromQuery = new URLSearchParams(window.location.search).get('pairingCode');
+if (fromQuery) setCode(fromQuery);
+
 render();
 refresh();
-boxes[0].focus();
+if (!fromQuery) boxes[0].focus();

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -67,6 +67,16 @@ def cleanPart(value):
     return value if value and value != "" and value != "None" else None
 
 
+@app.get("/")
+async def root(request: Request):
+    """The pairing page, at the address a room screen can print in full.
+
+    /pairing keeps working: the redirects after a refused code point at it, and
+    so may links made before this.
+    """
+    return await pairing_page(request)
+
+
 @app.get("/pairing")
 async def pairing_page(request: Request):
     """


### PR DESCRIPTION
QR_CODE_URL still aimed at /interact?pairingCode=, from before the pairing page existed on its own. A scan worked — /interact resolves the code and redirects — but the address printed under the QR is that URL without its query, so anyone reading it off the room screen and typing it landed on a page with nothing on it.

The proxy now serves the pairing page at its root as well, and the template points there: the shortest address a room screen can print and a visitor can key in. /pairing keeps working — the redirect after a refused code still goes there, and so would any link made before this.

The page also fills its boxes from a pairingCode in the query. A code read off the room screen is one the visitor is meant to use, unlike one the gateway has just turned down, which still clears them.

Tested from a phone: scanning the QR and typing the printed address both reach the pairing page with the code already in, and /pairing on its own still answers.