### PR TITLE
[Added] limit how often a pairing code can be guessed

### DIFF
--- a/deploy/proxyAPI/.env
+++ b/deploy/proxyAPI/.env
@@ -7,3 +7,10 @@ PROXY_ADMIN_TOKEN=
 
 ## Room-side resolution — leave empty to keep /gateway_id disabled
 PROXY_ROOM_TOKEN=
+
+## Pairing code attempts, per caller, before a 429. Zero disables the limit.
+PROXY_CODE_TRY_LIMIT=10
+PROXY_CODE_TRY_WINDOW=60
+## Read X-Forwarded-For to tell callers apart. Only where a front end sets it:
+## anyone can send that header.
+PROXY_TRUST_FORWARDED=

--- a/deploy/proxyAPI/pairing.js
+++ b/deploy/proxyAPI/pairing.js
@@ -27,6 +27,7 @@ const TEXTS = {
     close: 'Fermer ce message',
     errorPrefix: 'Le code',
     errorSuffix: 'est erroné ou expiré, veuillez réessayer.',
+    tooMany: 'Trop de tentatives. Patientez une minute avant de réessayer.',
     themeToLight: 'Passer en thème clair',
     themeToDark: 'Passer en thème sombre',
     boxLabel: (i) => `Caractère ${i + 1} sur ${CODE_LENGTH}`,
@@ -43,6 +44,7 @@ const TEXTS = {
     close: 'Dismiss this message',
     errorPrefix: 'Code',
     errorSuffix: 'is invalid or expired, please try again.',
+    tooMany: 'Too many attempts. Wait a minute before trying again.',
     themeToLight: 'Switch to light theme',
     themeToDark: 'Switch to dark theme',
     boxLabel: (i) => `Character ${i + 1} of ${CODE_LENGTH}`,
@@ -53,6 +55,9 @@ const TEXTS = {
 // are cleared rather than kept: a refused code is not worth correcting one
 // character at a time, re-reading it from the room screen is the point.
 let rejectedCode = '';
+
+// Set when the proxy has had enough attempts from here for the moment.
+let waited = false;
 
 let lang = localStorage.getItem('lang') || 'fr';
 if (!TEXTS[lang]) lang = 'fr';
@@ -179,15 +184,18 @@ function render() {
   // The rejected code is named in the message: on a screen where five boxes
   // now sit empty, "this code" alone would leave the reader wondering which.
   const banner = $('error-banner');
-  banner.hidden = !rejectedCode || dismissed;
-  if (rejectedCode) {
+  banner.hidden = (!rejectedCode && !waited) || dismissed;
+  $('error-close').setAttribute('aria-label', t.close);
+
+  if (waited) {
+    $('error-text').textContent = t.tooMany;
+  } else if (rejectedCode) {
     const text = $('error-text');
     text.textContent = '';
     text.append(t.errorPrefix + ' ');
     const codeEl = document.createElement('b');
     codeEl.textContent = rejectedCode;
     text.append(codeEl, ' ' + t.errorSuffix);
-    $('error-close').setAttribute('aria-label', t.close);
   }
 
   // The address the room screen shows under the code. Taken from where the
@@ -258,10 +266,12 @@ async function submit() {
   $('spinner').hidden = false;
   $('btn').disabled = true;
   rejectedCode = '';
+  waited = false;
   dismissed = false;
   render();
 
   let gwId = null;
+  let throttled = false;
   try {
     const res = await fetch('/pairing/resolve', {
       method: 'POST',
@@ -269,6 +279,10 @@ async function submit() {
       body: JSON.stringify({ code: value }),
     });
     if (res.ok) gwId = (await res.json())?.data?.gw_id || null;
+    // The proxy counts failed attempts and stops answering for a while. Telling
+    // the visitor their code is wrong would be untrue and send them straight
+    // back to try again.
+    throttled = res.status === 429;
   } catch (e) {
     // Unreachable proxy reads the same as a refused code here: either way the
     // visitor has nothing to do but try again.
@@ -280,7 +294,8 @@ async function submit() {
     return;
   }
 
-  rejectedCode = value;
+  rejectedCode = throttled ? '' : value;
+  waited = throttled;
   $('spinner').hidden = true;
   boxes.forEach((b) => { b.value = ''; });
   refresh();
@@ -297,6 +312,7 @@ window.addEventListener('pageshow', (e) => {
   if (!e.persisted) return;
   $('spinner').hidden = true;
   rejectedCode = '';
+  waited = false;
   dismissed = false;
   boxes.forEach((b) => { b.value = ''; });
   refresh();

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -524,6 +524,45 @@ def get_asset(file_name: str):
         filename=file_name,
     )
 
+# A pairing code is five characters out of thirty-six: some sixty million of
+# them, but fifty gateways mean fifty live codes at any moment and each lasts a
+# minute and a half. That is the one guessable secret in the system, so the two
+# routes that turn a code into a gateway count attempts.
+#
+# Behind a reverse proxy every request carries the proxy's own address, which
+# would put every visitor on one counter and let the first heavy hand lock out
+# the rest. X-Forwarded-For says who asked, but anyone can send it: it is read
+# only where PROXY_TRUST_FORWARDED says a front end sets it.
+codeTryLimit = int(os.getenv("PROXY_CODE_TRY_LIMIT", "10"))
+codeTryWindow = int(os.getenv("PROXY_CODE_TRY_WINDOW", "60"))
+trustForwarded = os.getenv("PROXY_TRUST_FORWARDED", "").lower() in ("1", "true", "yes")
+
+
+def callerAddress(request: Request):
+    if trustForwarded:
+        forwarded = request.headers.get("X-Forwarded-For", "")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def tooManyCodeTries(request: Request):
+    """True once a caller has spent its failed attempts for the window."""
+    if codeTryLimit <= 0:
+        return False
+    return int(redisClient.get(f"codetries:{callerAddress(request)}") or 0) >= codeTryLimit
+
+
+def noteFailedCodeTry(request: Request):
+    """Only failures count: someone reading a code off a room screen gets it
+    right, and it is the repeated miss that marks a search."""
+    if codeTryLimit <= 0:
+        return
+    key = f"codetries:{callerAddress(request)}"
+    if redisClient.incr(key) == 1:
+        redisClient.expire(key, codeTryWindow)
+
+
 @app.post("/pairing/resolve")
 async def pairingResolve(request: Request):
     """Turn a pairing code into a gw_id, without navigating anywhere.
@@ -536,6 +575,12 @@ async def pairingResolve(request: Request):
 
     /interact keeps accepting pairingCode as before.
     """
+    if tooManyCodeTries(request):
+        return JSONResponse(
+            status_code=429,
+            content={"status": "error", "error": {"code": 429, "detail": "Too many attempts"}, "data": None},
+        )
+
     try:
         body = await request.json()
     except Exception:
@@ -547,6 +592,7 @@ async def pairingResolve(request: Request):
 
     gwId = redisClient.get(f"pairing:{code}") if code else None
     if not gwId:
+        noteFailedCodeTry(request)
         # A malformed code and an unknown one get the same answer: the endpoint
         # says whether a code is live, and nothing else.
         return JSONResponse(
@@ -563,6 +609,8 @@ async def interact(request: Request):
     gwId = request.query_params.get("gwId") or request.query_params.get("gw_id")
     if not gwId:
         pairingCode = request.query_params.get("pairingCode")
+        if pairingCode and tooManyCodeTries(request):
+            raise HTTPException(status_code=429, detail="Too many attempts")
         if pairingCode:
             # Look‑up the gw_id stored under the pairing code
             resolvedGwId = redisClient.get(f"pairing:{pairingCode}")
@@ -577,6 +625,7 @@ async def interact(request: Request):
                 # retried the code that had just been turned down. The visitor
                 # is sent to the pairing page instead, which now checks a code
                 # through /pairing/resolve before going anywhere.
+                noteFailedCodeTry(request)
                 return RedirectResponse(url="/pairing", status_code=302)
         else:
             with open(os.path.join(assetDir, "pairing.html"), "r", encoding="utf-8") as f:

--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -524,11 +524,6 @@ def get_asset(file_name: str):
         filename=file_name,
     )
 
-# A pairing code is five characters out of thirty-six: some sixty million of
-# them, but fifty gateways mean fifty live codes at any moment and each lasts a
-# minute and a half. That is the one guessable secret in the system, so the two
-# routes that turn a code into a gateway count attempts.
-#
 # Behind a reverse proxy every request carries the proxy's own address, which
 # would put every visitor on one counter and let the first heavy hand lock out
 # the rest. X-Forwarded-For says who asked, but anyone can send it: it is read


### PR DESCRIPTION
A pairing code is five characters out of thirty-six. Sixty million of them sounds like plenty, but fifty gateways mean fifty live codes at any moment and each lasts ninety seconds, and nothing counted attempts: the one guessable secret in the system was open to being searched for.

The two routes that turn a code into a gateway now count failures per caller — ten in a minute, then 429 until the window passes. Only failures count: someone reading a code off a room screen gets it right, and it is the repeated miss that marks a search. The counter lives in Redis, which is already there, and expires on its own.

Behind a reverse proxy every request carries the proxy's own address, which would put every visitor on one counter and let the first heavy hand lock out the rest. X-Forwarded-For says who asked, but anyone can send it, so it is read only where PROXY_TRUST_FORWARDED says a front end sets it. The limits themselves are settings too, and zero turns them off.

The pairing page tells the two apart: a refused code names itself, a throttled one says to wait. Reading "this code is wrong" when it was never looked at would send the visitor straight back to try again.

Tested: ten wrong codes then 429, a right code as many times as you like, the counter expiring on its own, and the message in both languages.