### PR TITLE
[Changed] say what each control's state is, not what pressing it woul…

### DIFF
--- a/deploy/proxyAPI/interact-connexion.css
+++ b/deploy/proxyAPI/interact-connexion.css
@@ -4,6 +4,7 @@
 
 /* Leaving the call: a secondary button at the foot of the page, square-edged
    like the primary one. Not the action the visitor came for, but available. */
+/* The one action that ends something, in the colour that says so. */
 .hangup {
   display: block;
   width: 100%;
@@ -12,14 +13,14 @@
   border: 0;
   border-radius: .375rem;
   background: transparent;
-  box-shadow: inset 0 0 0 1px var(--bf);
-  color: var(--bf);
+  box-shadow: inset 0 0 0 1px var(--warning-txt);
+  color: var(--warning-txt);
   font: inherit;
   font-size: .9rem;
   font-weight: 500;
   cursor: pointer;
 }
-.hangup:hover { background: var(--bf); color: #fff; }
+.hangup:hover { background: var(--warning-txt); color: #fff; }
 .hangup:disabled { opacity: .45; cursor: default; }
 .hangup:disabled:hover { background: transparent; }
 

--- a/deploy/proxyAPI/interact-controls.css
+++ b/deploy/proxyAPI/interact-controls.css
@@ -7,12 +7,14 @@
    something it cannot see. */
 .ctrl-list { display: grid; gap: .5rem; margin-top: .8rem; }
 
+/* Two lines of text where the state is known, in the height one line used to
+   take: the padding gives back what the second line costs. */
 .ctrl {
   display: flex;
   align-items: center;
-  gap: .75rem;
+  gap: .7rem;
   width: 100%;
-  padding: .7rem .8rem;
+  padding: .5rem .7rem;
   border: 0;
   border-radius: .55rem;
   background: var(--tile);
@@ -26,7 +28,13 @@ button.ctrl { cursor: pointer; }
 button.ctrl:hover { box-shadow: inset 0 0 0 1.5px var(--bf); }
 button.ctrl:focus-visible { outline: 2px solid var(--bf); outline-offset: 2px; }
 
-.ctrl__icon { width: 1.4rem; height: 1.4rem; flex: none; display: inline-flex; }
+/* The icon carries the state as much as the words do: grey when off, green
+   when on, with a slash across it where one applies. */
+.ctrl__icon { width: 1.3rem; height: 1.3rem; flex: none; display: inline-flex; color: var(--muted); }
+.ctrl--on .ctrl__icon { color: var(--on); }
+/* The gap the slash sits in, cut in the colour behind the icon. Only the
+   microphone and the camera carry one. */
+.ctrl__icon .ctrl__cut { fill: var(--tile); }
 .ctrl__icon svg, .ctrl__icon img { width: 100%; height: 100%; fill: currentColor; object-fit: contain; }
 
 /* The command icons are black PNGs served by the gateway: the colour is in the
@@ -34,16 +42,18 @@ button.ctrl:focus-visible { outline: 2px solid var(--bf); outline-offset: 2px; }
    inversion — a tintable SVG would be cleaner, but would mean changing what
    the gateway serves. */
 [data-theme="dark"] .ctrl__icon img { filter: invert(1); }
-.ctrl__label { flex: 1; min-width: 0; }
+.ctrl__text { flex: 1; min-width: 0; line-height: 1.25; }
+.ctrl__state { display: block; font-size: .85rem; font-weight: 600; }
+.ctrl__hint { display: block; font-size: .7rem; color: var(--muted); }
 
 /* Switch. Shows the state the connector reports, never a local guess. */
 .ctrl__switch {
   appearance: none;
-  width: 2.5rem;
-  height: 1.5rem;
+  width: 2.4rem;
+  height: 1.4rem;
   flex: none;
   margin: 0;
-  border: 1px solid var(--bf);
+  border: 1px solid var(--border);
   border-radius: 1rem;
   background: var(--bg);
   position: relative;
@@ -57,11 +67,11 @@ button.ctrl:focus-visible { outline: 2px solid var(--bf); outline-offset: 2px; }
   width: 1.125rem;
   height: 1.125rem;
   border-radius: 50%;
-  background: var(--bf);
+  background: var(--muted);
   transition: transform .15s;
 }
-.ctrl__switch:checked { background: var(--bf); }
-.ctrl__switch:checked::after { background: var(--bg); transform: translateX(1rem); }
+.ctrl__switch:checked { background: var(--on); border-color: var(--on); }
+.ctrl__switch:checked::after { background: #fff; transform: translateX(1rem); }
 .ctrl__switch:focus-visible { outline: 2px solid var(--bf); outline-offset: 2px; }
 
 /* The conference being driven, on its platform */
@@ -170,8 +180,6 @@ button.ctrl:focus-visible { outline: 2px solid var(--bf); outline-offset: 2px; }
   justify-content: center;
   padding: 1rem;
 }
-/* Le cadre doit contenir l'image : sans cette borne, une capture haute pousse
-   les boutons hors de la boîte. */
 /* Full screen: the box takes the screen. Without this the browser switches and
    the box keeps its size, the image spilling out below. */
 #slide-preview:fullscreen { padding: 0; background: #000; }

--- a/deploy/proxyAPI/interact.js
+++ b/deploy/proxyAPI/interact.js
@@ -650,6 +650,75 @@ async function checkGwStatus() {
 // Which uiState field a command reflects, keyed on its icon: the digit and the
 // label differ from one platform to the next, the icon does not. A command
 // absent from here has no state to show and stays a button.
+// The shapes the six known commands draw, and the words they say in either
+// state. config.json gives one label per command — "Muet / Actif" — which names
+// the action rather than the state: a switch needs to say what is, not what
+// pressing it would do. A command not listed here keeps its config label and
+// the icon the gateway serves.
+const CTRL_SHAPE = {
+  microphone_icon:   'M12 14a3 3 0 0 0 3-3V5a3 3 0 1 0-6 0v6a3 3 0 0 0 3 3zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 6 6.9V21h2v-3.1A7 7 0 0 0 19 11h-2z',
+  camera_icon:       'M17 10.5V7a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-3.5l4 4v-11l-4 4z',
+  chat_icon:         'M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2z',
+  hand_icon:         'M18 11V6a2 2 0 0 0-4 0V4a2 2 0 0 0-4 0v1a2 2 0 0 0-4 0v8l-1.6-1.6A2 2 0 0 0 1.6 14L6 20a5 5 0 0 0 4 2h6a5 5 0 0 0 5-5v-6a2 2 0 0 0-3 0z',
+  participants_icon: 'M9 11a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7zm0 1.8c-3 0-6 1.5-6 3.4V19h12v-2.8c0-1.9-3-3.4-6-3.4zM17.5 11a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 1.6c-.7 0-1.4.1-2 .3 1.3.9 2 2 2 3.3V19h5v-2.5c0-1.7-2.4-3-5-3z',
+  info_icon:         'M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z',
+};
+
+// A slash says "nothing is going out" — it belongs on the microphone and the
+// camera. A hidden panel is not a forbidden one, so chat, participants, info
+// and the hand carry none: grey against green, with the words beside them,
+// says enough.
+const CTRL_SLASHED = ['microphone_icon', 'camera_icon'];
+
+const CTRL_WORDS = {
+  fr: {
+    microphone_icon:   [['Micro coupé', 'Personne ne vous entend'], ['Micro actif', 'Vous êtes entendu']],
+    camera_icon:       [['Caméra coupée', 'Votre image n\u2019est pas diffusée'], ['Caméra active', 'Votre image est diffusée']],
+    chat_icon:         [['Chat masqué', 'Non affiché en salle'], ['Chat affiché', 'Visible sur l\u2019écran de la salle']],
+    hand_icon:         [['Main baissée', 'Vous ne demandez pas la parole'], ['Main levée', 'Vous demandez la parole']],
+    participants_icon: [['Participants masqués', 'Liste non affichée en salle'], ['Participants affichés', 'Liste visible sur l\u2019écran']],
+    info_icon:         [['Informations masquées', 'Non affichées en salle'], ['Informations affichées', 'Visibles sur l\u2019écran']],
+  },
+  en: {
+    microphone_icon:   [['Microphone off', 'Nobody can hear you'], ['Microphone on', 'You can be heard']],
+    camera_icon:       [['Camera off', 'Your picture is not sent'], ['Camera on', 'Your picture is being sent']],
+    chat_icon:         [['Chat hidden', 'Not shown in the room'], ['Chat shown', 'Visible on the room screen']],
+    hand_icon:         [['Hand down', 'You are not asking to speak'], ['Hand raised', 'You are asking to speak']],
+    participants_icon: [['Participants hidden', 'List not shown in the room'], ['Participants shown', 'List visible on the screen']],
+    info_icon:         [['Details hidden', 'Not shown in the room'], ['Details shown', 'Visible on the screen']],
+  },
+};
+
+// Writes a row's state into it: the class, the icon and the two lines. Called
+// when the row is built and again on every read-back.
+function paintCtrlRow(row, icon, on, fallbackLabel) {
+  if (!row) return;
+  row.classList.toggle('ctrl--on', on);
+  row.querySelector('.ctrl__icon').innerHTML = ctrlIcon(icon, on);
+
+  const words = (CTRL_WORDS[currentLang] || {})[icon];
+  const state = row.querySelector('.ctrl__state');
+  const hint = row.querySelector('.ctrl__hint');
+  if (words) {
+    state.textContent = words[on ? 1 : 0][0];
+    hint.textContent = words[on ? 1 : 0][1];
+  } else if (fallbackLabel !== undefined) {
+    state.textContent = fallbackLabel;
+  }
+}
+
+function ctrlIcon(icon, on) {
+  const shape = CTRL_SHAPE[icon];
+  if (!shape) return getIcon(icon);          // a command we do not know: the gateway's own
+  // Two strokes: one in the page's background colour to carve a gap out of the
+  // shape, the slash itself on top. On a solid icon a bare line would vanish
+  // into it.
+  const slash = !on && CTRL_SLASHED.includes(icon)
+    ? '<path d="M3 1.6 22.4 21l-1.4 1.4L1.6 3z" class="ctrl__cut"/>' +
+      '<path d="M3.6 2.3 21.7 20.4l-1.3 1.3L2.3 3.6z"/>' : '';
+  return `<svg viewBox="0 0 24 24" aria-hidden="true">${'<path d="' + shape + '"/>'}${slash}</svg>`;
+}
+
 const CTRL_STATE = {
   microphone_icon:   (ui) => ui.media && ui.media.microphone,
   camera_icon:       (ui) => ui.media && ui.media.camera,
@@ -700,9 +769,16 @@ async function syncCtrlState() {
   const ui = await fetchCtrlState();
   ctrlState = ui;
   if (!ui) return;
+  // The switch is not the only thing that says what the state is: the words
+  // and the icon say it too, and moving one without the others leaves the row
+  // contradicting itself.
   document.querySelectorAll('.ctrl__switch[data-icon]').forEach((sw) => {
-    const probe = CTRL_STATE[sw.dataset.icon];
-    if (probe) sw.checked = probe(ui) === true;
+    const icon = sw.dataset.icon;
+    const probe = CTRL_STATE[icon];
+    if (!probe) return;
+    const on = probe(ui) === true;
+    sw.checked = on;
+    paintCtrlRow(sw.closest('.ctrl'), icon, on);
   });
 }
 
@@ -755,17 +831,20 @@ async function renderMenuOptions() {
     if (icon.toLowerCase().includes('chat')) hasChat = true;
 
     if (probe && ctrlState) {
+      const on = probe(ctrlState) === true;
+
       const row = document.createElement('label');
       row.className = 'ctrl';
-      row.innerHTML = `<span class="ctrl__icon">${getIcon(opt.icon)}</span>` +
-                      `<span class="ctrl__label"></span>`;
-      row.querySelector('.ctrl__label').textContent = label;
+      row.innerHTML = '<span class="ctrl__icon"></span>' +
+                      '<span class="ctrl__text"><span class="ctrl__state"></span>' +
+                      '<span class="ctrl__hint"></span></span>';
+      paintCtrlRow(row, icon, on, label);
 
       const sw = document.createElement('input');
       sw.type = 'checkbox';
       sw.className = 'ctrl__switch';
       sw.dataset.icon = icon;
-      sw.checked = probe(ctrlState) === true;
+      sw.checked = on;
       sw.addEventListener('change', async () => {
         await sendKey(opt.dtmf);
         await syncCtrlState();
@@ -777,9 +856,12 @@ async function renderMenuOptions() {
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'ctrl';
-      btn.innerHTML = `<span class="ctrl__icon">${getIcon(opt.icon)}</span>` +
-                      `<span class="ctrl__label"></span>`;
-      btn.querySelector('.ctrl__label').textContent = label;
+      // Same shape as a switch row, one line instead of two: the connector
+      // says nothing about this command's state, so the config label stands
+      // on its own.
+      btn.innerHTML = `<span class="ctrl__icon">${ctrlIcon(icon, true)}</span>` +
+                      '<span class="ctrl__text"><span class="ctrl__state"></span></span>';
+      btn.querySelector('.ctrl__state').textContent = label;
       btn.onclick = async () => {
         await sendKey(opt.dtmf);
         await syncCtrlState();

--- a/deploy/proxyAPI/shared.css
+++ b/deploy/proxyAPI/shared.css
@@ -14,6 +14,7 @@
   --bg: #fff;
   --tile: #f6f6f6;
   --border: #ddd;
+  --on: #18753c;
   --warning-bg: #fdeeee;
   --warning-txt: #b34000;
 }
@@ -24,6 +25,7 @@
   --bg: #161616;
   --tile: #1e1e1e;
   --border: #353535;
+  --on: #27a658;
   --warning-bg: #2e1a12;
   --warning-txt: #fc5d00;
 }


### PR DESCRIPTION
…d do

config.json gives one label per command — "Muet / Actif", "Show / Hide chat" — which names the action. Next to a switch that reads as a puzzle: the visitor has to work out which half of the label is the current state.

Where the connector reports a state, the row now says what it is and what it means: "Micro coupé / Personne ne vous entend". The icon carries it too, grey when off and green when on, with a slash across the microphone and the camera — nothing is going out. A hidden panel is not a forbidden one, so chat, participants, details and the hand carry none.

Those six icons are drawn by the page rather than served by the gateway. They had to be, to have an off state at all, and it means they follow the palette instead of needing to be inverted on the dark theme. A command the page does not know keeps the gateway's icon and its config label.

The state is written into the row in one place, called when the row is drawn and again on every read-back: the switch moving while the words sat still is exactly the kind of thing that had #73 reverted.

Two lines fit in the height one used to take. Hanging up is red now: it is the one action that ends something.

Tested on Visio, which reports its state, and on Jitsi, which does not: six switches with words on the first, eight plain buttons on the second, both themes, both languages, and the row following a control pressed on the room tablet.