### PR TITLE
[Removed] a second /status route that never answered

### DIFF
--- a/deploy/proxyAPI/proxy.py
+++ b/deploy/proxyAPI/proxy.py
@@ -912,10 +912,6 @@ async def ivrConfigGateway(request: Request):
 async def ivrConfigGateway(request: Request):
     return await genericGatewayProxy(request, "browsing")
 
-@app.api_route("/status", methods=["GET"])
-async def statusGatewayProxy(request: Request):
-    return await genericGatewayProxy(request, "status")
-
 @app.api_route("/icon/{icon_name}", methods=["GET"])
 async def iconGateway(request: Request, icon_name: str):
     return await genericGatewayProxy(request, f"icon/{icon_name}")


### PR DESCRIPTION
/status was declared twice: once reading the gateway's state from Redis, once relaying to the gateway itself. FastAPI takes the first and ignores the rest, so the relay had never answered a request since the day it was added.

Nothing looks for what it would have returned. The companion page reads the Redis one, and the gateway manager reads /admin/statuses. The proxy's own monitor already fetches /gateway/status from each gateway — which is where the Redis entry comes from in the first place, making the relay a second path to the same data.

Tested: /status?gw_id= answers as before, and a call through the IVR behaves unchanged.